### PR TITLE
Aanpassing agenda api filter

### DIFF
--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -29,7 +29,9 @@ class AgendaController extends Controller
         }
         if($request->has('startDate')){
             $startDate = Carbon::createFromFormat('d-m-Y', $request->get('startDate'))->setTime(0, 0, 0);
-            $agendaItemQeury->where("startDate",'>=',$startDate);
+            $agendaItemQeury
+                ->where("startDate",'>=',$startDate)
+                ->orWhere("endDate",'>=',$startDate);
         }
         if($request->has('endDate')){
             $endDate = Carbon::createFromFormat('d-m-Y', $request->get('endDate'))->setTime(0, 0, 0);


### PR DESCRIPTION
De agenda api geeft nu alle agenda item terug met een start datum gelijk of later aan de gegeven dagen en waarbij de eind datum gelijk of na de opgegeven startdatum liggen.

Dit fixed issue #1 