### PR TITLE
Store summernote images in file storage

### DIFF
--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class StorageController extends Controller
+{
+    /**
+     * StorageController constructor.
+     */
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('authorize:'.\Illuminate\Support\Facades\Config::get('constants.Content_administrator'));
+    }
+
+    public function uploadImage(Request $request)
+    {
+        $path = $request->file('image')->store('image_uploads', 'public');
+
+        return '/' . $path;
+    }
+
+    public function deleteImage(Request $request)
+    {
+        Storage::disk('public')->delete($request->path);
+    }
+}

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,4 +1,6 @@
-var summernoteSettings = {
+require('./bootstrap');
+
+window.summernoteSettings = {
     height: 300,
     toolbar: [
         ['style', ['style']],
@@ -11,7 +13,42 @@ var summernoteSettings = {
         ['view', ['fullscreen', 'codeview']],
         ['help', ['help']],
         ['myotherbutton', ['emailsDropDown']],
-    ]
+    ],
+    callbacks: {
+        onImageUpload: function (files) {
+            uploadFile(files[0], this);
+        },
+        onMediaDelete: function ($target, editor) {
+            deleteFile($target)
+        }
+    }
+};
+
+function uploadFile (file, summernote) {
+    data = new FormData();
+    data.append('image', file);
+
+    axios
+        .post('/images/upload', data)
+        .then(response => {
+            $(summernote).summernote('insertImage', response.data);
+        });
+}
+
+function deleteFile ($target) {
+    if ($target.is('img')) {
+        let path = $target.attr('src');
+
+        if (path.startsWith('data:image')) {
+            // This is a base64 image, so no need to remove it from storage.
+            return;
+        }
+
+        axios
+            .delete('/images/delete', {params: {
+                    path: path,
+                }});
+    }
 }
 
 // Cookie utils

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -1,0 +1,10 @@
+window.axios = require('axios');
+window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
+let token = document.head.querySelector('meta[name="csrf-token"]');
+
+if (token) {
+    window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
+} else {
+    console.error('CSRF token not found: https://laravel.com/docs/csrf#csrf-x-csrf-token');
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,8 @@ Route::resource('frontEndReplacement', 'FrontEndReplacementController');
 Route::resource('mailList', 'MailListController');
 Route::post('/lidworden', 'PendingUserController@storePendingUser');
 Route::resource('books', 'LibraryController');
+Route::post('images/upload', 'StorageController@uploadImage');
+Route::delete('images/delete', 'StorageController@deleteImage');
 
 //inschrijf routes
 Route::get('forms/{agendaItem}', array('as' => 'editSchedule', 'uses' => 'InschrijfController@showPersonalRegistrationForm'));

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -26,8 +26,7 @@ mix.styles([
 mix.copyDirectory("resources/assets/img","public/img")
    .copyDirectory("node_modules/summernote/dist/font","public/css/vendor/font");
 
-mix.copy("resources/assets/js/app.js","public/js")
-   .copy("node_modules/jquery/dist/jquery.js", "public/js/vendor")
+mix.copy("node_modules/jquery/dist/jquery.js", "public/js/vendor")
    .copy("node_modules/summernote/dist/summernote-bs4.js", "public/js/vendor/summernote.js")
    .copy("node_modules/summernote/dist/summernote-bs4.css", "public/css/vendor/summernote.css")
    .copy("node_modules/popper.js/dist/umd/popper.js", "public/js/vendor")
@@ -35,6 +34,8 @@ mix.copy("resources/assets/js/app.js","public/js")
    .copy("node_modules/tempusdominus-bootstrap-4/build/js/tempusdominus-bootstrap-4.js", "public/js/vendor/tempusdominus.js")
    .copy("node_modules/bootstrap/dist/js/bootstrap.js", "public/js/vendor");
 
+// App js
+mix.js('resources/assets/js/app.js', 'public/js');
 
 //vuejs components
 mix.js('resources/assets/vue/agenda.js','public/js');


### PR DESCRIPTION
## What was the problem? ##
Currently images in the summernote editor are converted to a base64 representation and stored in the page. This makes the editor very slow as these base64 strings can get huge.

## How was it solved? ##
When an image gets uploaded in the editor, a POST request is sent to the server which uploads the file in the public storage folder. Same goes for removing an image.

## Deployment instructions ##
Changes should be entirely backwards compatible. Just a `npm run production` is required.

## Known issues ##
All images are publicly accessible, even when the page is actually only visible for registered users. Fixing this is non-trivial as it is not straightforward whether the image is going to be part of a private page or not, at the time of uploading.