### PR TITLE
Filter op agenda beheer pagina

### DIFF
--- a/app/Http/Controllers/AgendaItemController.php
+++ b/app/Http/Controllers/AgendaItemController.php
@@ -36,9 +36,7 @@ class AgendaItemController extends Controller
      */
     public function index()
     {
-        $agendaItems = $this->_agendaItemRepository->all(array('title','startdate','endDate','id','application_form_id'));
-
-        return view('beheer.agendaItem.index',compact('agendaItems'));
+        return view('beheer.agendaItem.index');
     }
 
     /**

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -49,6 +49,7 @@ class AgendaController extends Controller
                 "thumbnail" => $agendaItem->getImageUrl(),
                 "startDate" => \Carbon\Carbon::parse($agendaItem->startDate)->format('d M'),
                 "endDate" => $agendaItem->endDate,
+                "full_startDate" => $agendaItem->startDate,
                 "category" => $agendaItem->agendaItemCategory->categorieName->text(),
                 "text" => $agendaItem->agendaItemShortDescription->text(),
                 "formId" => $agendaItem->getApplicationForm,

--- a/resources/views/beheer/agendaItem/index.blade.php
+++ b/resources/views/beheer/agendaItem/index.blade.php
@@ -18,7 +18,6 @@
         <div class="col-md-6">
             <h1>{{trans("AgendaItems.agendaItems")}}</h1>
         </div>
-
         <div class="col-md-6">
             <div class="btn-group mt-2 float-md-right" role="group" aria-label="Actions">
                 <a href="{{url('agendaItems/create')}}" class="btn btn-primary">
@@ -28,7 +27,21 @@
             </div>
         </div>
     </div>
-    <table id="users" class="table table-striped dt-responsive nowrap" style="width:100%">
+    <div class="row mb-3">
+        <div class="col-md-3">
+            <div class="form-group">
+                {!! Form::label('startDate', trans('AgendaItems.startDate')) !!}
+                <div class="input-group date" id="startDateBox" data-target-input="nearest">
+                    <input type='text' class="form-control datetimepicker-input" id="startDate" name="startDate" data-target="#startDateBox" value="{{\Carbon\Carbon::now()->addHours(1)->format('d-m-Y')}}" required/>
+                    <div class="input-group-append" data-target="#startDateBox" data-toggle="datetimepicker">
+                        <div class="input-group-text"><i class="ion-calendar"></i></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <table id="agenda-items" class="table table-striped dt-responsive nowrap" style="width:100%">
         <thead>
         <tr>
             <th>{{trans('AgendaItems.title')}}</th>
@@ -38,27 +51,82 @@
         </tr>
         </thead>
         <tbody>
-
-        @foreach ($agendaItems as $agendaItem)
-            <tr>
-                <td>{{$agendaItem->agendaItemTitle->text()}}</td>
-                <td>{{\Carbon\Carbon::parse($agendaItem->startdate)->format('d M Y')}}</td>
-                <td>{{\Carbon\Carbon::parse($agendaItem->endDate)->format('d M Y')}}</td>
-                <td>
-                    <a href="{{url('/agendaItems/' . $agendaItem->id . '/edit')}}"><span title="{{trans('AgendaItems.edit')}}" class="ion-edit" aria-hidden="true"></span></a>
-                    <a href="{{url('/agendaItems/'. $agendaItem->id)}}"><span title="{{trans("AgendaItems.show")}}" class="ion-eye" aria-hidden="true"></span></a>
-                    @if($agendaItem->application_form_id != null)
-                        <a href="{{url('/forms/users/'. $agendaItem->id)}}"><span title="{{trans("AgendaItems.showsignups")}}" class="ion-android-list" aria-hidden="true"></span></a>
-                    @endif
-                </td>
-            </tr>
-        @endforeach
         </tbody>
     </table>
 @endsection
 
-@push('scripts')
-    <script type="text/javascript">
+@push('styles')
+    <link rel="stylesheet" type="text/css" href="{{mix("css/vendor/datatables.css")}}">
+@endpush
 
+@push('scripts')
+    <script src="{{mix("js/vendor/datatables.js")}}" type="text/javascript"></script>
+    <script src="{{mix("js/vendor/moment.js")}}" type="text/javascript"></script>
+    <script src="{{mix("js/vendor/tempusdominus.js")}}" type="text/javascript"></script>
+    <script type="text/javascript">
+        $('#startDateBox').datetimepicker({
+            locale: 'nl',
+            format: "DD-MM-YYYY",
+            icons: {
+                time: 'ion-clock',
+                date: 'ion-calendar',
+                up: 'ion-android-arrow-up',
+                down: 'ion-android-arrow-down',
+                previous: 'ion-chevron-left',
+                next: 'ion-chevron-right',
+                today: 'ion-calendar',
+                clear: 'ion-trash-a',
+                close: 'ion-close'
+            }
+        });
+
+        let agendaTable = $('#agenda-items').DataTable({
+            "order": [[ 1, "asc" ]],
+            "ajax": {
+                'url' : getUrl(),
+                "dataSrc": "agendaItems"
+            },
+            "columns": [
+                { "data": "title" },
+                { "data": function(data){
+                        return formatDate(data.full_startDate);
+                    }},
+                { "data": function(data){
+                    return formatDate(data.endDate);
+                    }},
+                { "data": function(data){
+                    return getAgendaItemActions(data);
+                }},
+            ]
+        });
+
+        $("#startDateBox").on("change.datetimepicker", function (e) {
+            agendaTable.ajax.url(getUrl()).load();
+        });
+
+        function formatDate(date){
+            date = moment(date);
+            return date.format("DD-MM-YYYY HH:mm")
+        }
+
+        function getAgendaItemActions(data){
+            let actions = "";
+            actions += '<a href="{{url('/agendaItems/')}}' + data.id + '/edit"><span title="{{trans('AgendaItems.edit')}}" class="ion-edit" aria-hidden="true"></span></a>';
+            actions += '<a href="{{url('/agendaItems/')}}' + data.id + '"><span title="{{trans('AgendaItems.show')}}" class="ion-eye" aria-hidden="true"></span></a>';
+            if(data.application_form_id != null){
+                actions += '<a href="{{url('/forms/users/')}}' + data.id + '"><span title="{{trans("AgendaItems.showsignups")}}" class="ion-android-list" aria-hidden="true"></span></a>';
+            }
+            return actions;
+        }
+
+        function getUrl(){
+            let params = "";
+            let datePicker = $('#startDate');
+            if(datePicker.val() != ""){
+                params += "&startDate=" + datePicker.val();
+            }
+
+            return "{{url("api/agenda")}}?" + params;
+        }
     </script>
 @endpush


### PR DESCRIPTION
Op de agenda beheer pagina is een filter toegevoegd voor het aangeven van de start datum. 
Standaard worden vanaf nu de agenda items getoond met een minimale start datum van vandaag zodat we de oude agenda items niet meer zien. 
Mochten mensen die toch nog willen bekijken kan met het filter een andere datum gekozen worden.
#3 