### PR TITLE
Thumbnails improvement

### DIFF
--- a/app/Http/Controllers/AgendaItemController.php
+++ b/app/Http/Controllers/AgendaItemController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\AgendaItem;
 use App\repositories\RepositorieFactory;
-use Folklore\Image\Facades\Image;
+use Intervention\Image\ImageManagerStatic as Image;
 use Illuminate\Http\Request;
 
 class AgendaItemController extends Controller
@@ -86,7 +86,7 @@ class AgendaItemController extends Controller
 
             //resize image
             $img_path = "../storage/app/public/" . $agendaItem->image_url;
-            Image::make($img_path)->crop(400, 300)->save($img_path);
+            Image::make($img_path)->fit(400, 300)->save($img_path);
         }
 
         \Session::flash("message",trans('AgendaItems.added'));
@@ -154,7 +154,7 @@ class AgendaItemController extends Controller
 
             //resize image
             $img_path = "../storage/app/public/" . $agendaItem->image_url;
-            Image::make($img_path)->crop(400, 300)->save($img_path);
+            Image::make($img_path)->fit(400, 300)->save($img_path);
         }
 
         \Session::flash("message",trans('AgendaItems.edited'));

--- a/app/Http/Controllers/AgendaItemController.php
+++ b/app/Http/Controllers/AgendaItemController.php
@@ -6,7 +6,6 @@ use App\AgendaItem;
 use App\repositories\RepositorieFactory;
 use Folklore\Image\Facades\Image;
 use Illuminate\Http\Request;
-use Imagine\Image\Box;
 
 class AgendaItemController extends Controller
 {
@@ -86,10 +85,8 @@ class AgendaItemController extends Controller
             $agendaItem->save();
 
             //resize image
-            Image::make("../storage/app/public/" . $agendaItem->image_url,array(
-                'width' => 400,
-                'height' => 200
-            ))->save("../storage/app/public/" . $agendaItem->image_url);
+            $img_path = "../storage/app/public/" . $agendaItem->image_url;
+            Image::make($img_path)->crop(400, 300)->save($img_path);
         }
 
         \Session::flash("message",trans('AgendaItems.added'));
@@ -156,10 +153,8 @@ class AgendaItemController extends Controller
             $agendaItem->save();
 
             //resize image
-            Image::make("../storage/app/public/" . $agendaItem->image_url,array(
-                'width' => 400,
-                'height' => 200
-            ))->save("../storage/app/public/" . $agendaItem->image_url);
+            $img_path = "../storage/app/public/" . $agendaItem->image_url;
+            Image::make($img_path)->crop(400, 300)->save($img_path);
         }
 
         \Session::flash("message",trans('AgendaItems.edited'));
@@ -190,6 +185,7 @@ class AgendaItemController extends Controller
             'applicationForm' => 'required|numeric|min:0',
             'endDate' => 'required|date',
             'startDate' => 'required|date',
+            'thumbnail' => 'required'
         ]);
     }
 }

--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -19,6 +19,6 @@ class ManageController extends Controller
             abort(403, trans('validation.Unauthorized'));
         }
 
-        return view('beheer/home', compact('menu'));
+        return view('beheer/home');
     }
 }

--- a/app/Http/Controllers/NewsItemController.php
+++ b/app/Http/Controllers/NewsItemController.php
@@ -100,9 +100,9 @@ class NewsItemController extends Controller
             $newsItem->save();
 
             //resize both images
-            $header_path = "../storage/app/public/" . $newsItem->image_url;
+            $header_path = storage_path('app/public/' . $newsItem->image_url);
             Image::make($header_path)->fit(1200, 500)->save($header_path);
-            $thumb_path = "../storage/app/public/" . $newsItem->thumbnail_url;
+            $thumb_path = storage_path('app/public/' . $newsItem->thumbnail_url);
             Image::make($thumb_path)->fit(400, 300)->save($thumb_path);
         }
 

--- a/app/Http/Controllers/NewsItemController.php
+++ b/app/Http/Controllers/NewsItemController.php
@@ -6,6 +6,8 @@ use App\NewsItem;
 use App\repositories\RepositorieFactory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
+use Intervention\Image\ImageManagerStatic as Image;
+
 
 class NewsItemController extends Controller
 {
@@ -44,10 +46,22 @@ class NewsItemController extends Controller
 
         //save image
         if($request->hasFile('thumbnail')){
-            $name  = $newsItem->id . '-thumbnail.' . $request->thumbnail->extension();
-            $request->file('thumbnail')->storeAs('newsItems', $name,'public');
-            $newsItem->image_url = 'newsItems/' .  $name;
+            //larger header image for detail view
+            $name_header = $newsItem->id . '-header.' . $request->thumbnail->extension();
+            $request->file('thumbnail')->storeAs('newsItems', $name_header,'public');
+            $newsItem->image_url = 'newsItems/' .  $name_header;
+
+            //smaller thumbnail image for list view
+            $name_thumbnail = $newsItem->id . '-header.' . $request->thumbnail->extension();
+            $request->file('thumbnail')->storeAs('newsItems', $name_thumbnail,'public');
+            $newsItem->thumbnail_url = 'newsItems/' .  $name_header;
             $newsItem->save();
+
+            //resize both images
+            $header_path = "../storage/app/public/" . $newsItem->image_url;
+            Image::make($header_path)->fit(1200, 500)->save($header_path);
+            $thumb_path = "../storage/app/public/" . $newsItem->thumbnail_url;
+            Image::make($thumb_path)->fit(400, 300)->save($thumb_path);
         }
 
         \Session::flash("message",trans('NewsItem.added'));
@@ -74,10 +88,22 @@ class NewsItemController extends Controller
 
         //save image
         if($request->hasFile('thumbnail')){
-            $name  = $newsItem->id . '-thumbnail.' . $request->thumbnail->extension();
-            $request->file('thumbnail')->storeAs('newsItems', $name,'public');
-            $newsItem->image_url = 'newsItems/' .  $name;
+            //larger header image for detail view
+            $name_header = $newsItem->id . '-header.' . $request->thumbnail->extension();
+            $request->file('thumbnail')->storeAs('newsItems', $name_header,'public');
+            $newsItem->image_url = 'newsItems/' .  $name_header;
+
+            //smaller thumbnail image for list view
+            $name_thumbnail = $newsItem->id . '-thumbnail.' . $request->thumbnail->extension();
+            $request->file('thumbnail')->storeAs('newsItems', $name_thumbnail,'public');
+            $newsItem->thumbnail_url = 'newsItems/' .  $name_thumbnail;
             $newsItem->save();
+
+            //resize both images
+            $header_path = "../storage/app/public/" . $newsItem->image_url;
+            Image::make($header_path)->fit(1200, 500)->save($header_path);
+            $thumb_path = "../storage/app/public/" . $newsItem->thumbnail_url;
+            Image::make($thumb_path)->fit(400, 300)->save($thumb_path);
         }
 
         \Session::flash("message",trans('NewsItem.edited'));

--- a/app/NewsItem.php
+++ b/app/NewsItem.php
@@ -34,7 +34,7 @@ class NewsItem extends Model
     }
 
     public function getThumbnailUrl(){
-        if($this->image_url != ""){
+        if($this->thumbnail_url != ""){
             return \Storage::disk('public')->url($this->thumbnail_url);
         } else {
             return "/img/header-3.jpg";

--- a/app/NewsItem.php
+++ b/app/NewsItem.php
@@ -12,6 +12,7 @@ class NewsItem extends Model
         'title',
         'text',
         'image_url',
+        'thumbnail_url',
         'author'
     ];
 
@@ -27,6 +28,14 @@ class NewsItem extends Model
     public function getImageUrl(){
         if($this->image_url != ""){
             return \Storage::disk('public')->url($this->image_url);
+        } else {
+            return "/img/header-3.jpg";
+        }
+    }
+
+    public function getThumbnailUrl(){
+        if($this->image_url != ""){
+            return \Storage::disk('public')->url($this->thumbnail_url);
         } else {
             return "/img/header-3.jpg";
         }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         "laravelcollective/html": "~5.4",
         "barryvdh/laravel-ide-helper": "^2.4",
         "maatwebsite/excel": "~2.1.0",
-        "folklore/image": "0.2.*",
         "bogardo/mailgun": "^5.0",
         "php-http/guzzle6-adapter": "^1.1",
         "laravel/tinker": "^1.0",

--- a/config/app.php
+++ b/config/app.php
@@ -169,7 +169,6 @@ return [
         /*
          * Package Service Providers...
          */
-        Folklore\Image\ImageServiceProvider::class,
         //
 
         /*
@@ -231,7 +230,6 @@ return [
         'View' => Illuminate\Support\Facades\View::class,
         'Form' => Collective\Html\FormFacade::class,
         'Html' => Collective\Html\HtmlFacade::class,
-        'Image' => Folklore\Image\Facades\Image::class,
         'Excel' => Maatwebsite\Excel\Facades\Excel::class,
         'Mailgun' => Bogardo\Mailgun\Facades\Mailgun::class,
         ],

--- a/database/migrations/2019_03_21_111809_add_thumbnail_to_news.php
+++ b/database/migrations/2019_03_21_111809_add_thumbnail_to_news.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddThumbnailToNews extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('news_items',function(Blueprint $table){
+            $table->string('thumbnail_url')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('news_items',function(Blueprint $table){
+            $table->dropColumn('thumbnail_url')->nullable();
+        });
+    }
+}

--- a/database/migrations/2019_03_21_111809_add_thumbnail_to_news.php
+++ b/database/migrations/2019_03_21_111809_add_thumbnail_to_news.php
@@ -26,7 +26,7 @@ class AddThumbnailToNews extends Migration
     public function down()
     {
         Schema::table('news_items',function(Blueprint $table){
-            $table->dropColumn('thumbnail_url')->nullable();
+            $table->dropColumn('thumbnail_url');
         });
     }
 }

--- a/resources/views/beheer/agendaItem/create_edit_image.blade.php
+++ b/resources/views/beheer/agendaItem/create_edit_image.blade.php
@@ -6,7 +6,7 @@
         <span>{{trans("AgendaItems.tumpnailImage")}}</span>
         <div class="form-group mt-2">
             <div class="custom-file">
-              <input type="file" class="custom-file-input" id="thumbnail" name="thumbnail">
+              <input type="file" class="custom-file-input" id="thumbnail" name="thumbnail" required="required">
               <label class="custom-file-label" for="customFile">Choose file</label>
             </div>
         </div>

--- a/resources/views/front-end/news.blade.php
+++ b/resources/views/front-end/news.blade.php
@@ -15,9 +15,9 @@
             @foreach($newsItems as $newsItem)
             <div class="col-lg-4 col-md-6 d-flex flex-wrap">
                 <div class="card w-100 position-relative">
-                    @if($newsItem->image_url != "")
+                    @if($newsItem->thumbnail_url != "")
                     <a href="/nieuws/{{ $newsItem->id }}">
-                        <img class="card-img-top" src="{{$newsItem->getImageUrl()}}" alt="Card image cap">
+                        <img class="card-img-top" src="{{$newsItem->getThumbnailUrl()}}" alt="Card image cap">
                     </a>
                     @endif
                     <span class="card-date position-absolute bg-light py-1 px-3 rounded">{{\Carbon\Carbon::parse($newsItem->created_at)->format('d M')}}</span>


### PR DESCRIPTION
Aantal dingen aangepakt om de thumbnails van nieuws en de agenda beter te maken:

- Agenda thumbnails worden nu allemaal gecropped naar 400x300
- Bij de nieuws items werden de volledige (soms wel 1 MB) afbeeldingen gebruikt als thumbnails! Dit is nu net zoals bij de agenda items
- Voor nieuws zijn er nu twee soorten afbeeldingen die worden opgeslagen een thumbnail (400x300) en een header image (1200x500). Hiervoor is een extra database kolom aangemaakt.
- Agenda thumbnails zijn verplicht

Fixes #51 