### PR TITLE
Ical calendar

### DIFF
--- a/app/Http/Controllers/AgendaItemController.php
+++ b/app/Http/Controllers/AgendaItemController.php
@@ -185,7 +185,6 @@ class AgendaItemController extends Controller
             'applicationForm' => 'required|numeric|min:0',
             'endDate' => 'required|date',
             'startDate' => 'required|date',
-            'thumbnail' => 'required'
         ]);
     }
 }

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -11,57 +11,23 @@ class ICalController extends Controller
     public function getAgendaItemsICalObject()
     {
         $agenda_items = AgendaItem::all();
-        define('ICAL_FORMAT', 'Ymd\THis');
- 
-        $eol = "\r\n";
-        $icalObject = "BEGIN:VCALENDAR" . $eol .
-        "VERSION:2.0"  . $eol .
-        "METHOD:PUBLISH" . $eol .
-        "NAME:ESAC Agenda" . $eol .
-        "X-WR-CALNAME:ESAC Agenda" . $eol .
-        "DESCRIPTION:Een overzicht van alle ESAC activiteiten" . $eol .
-        "X-WR-CALDESC:Een overzicht van alle ESAC activiteiten" . $eol .
-        "PRODID:-//Eindhovense Studenten Alpen Club//Agenda//NL"  . $eol .
-        "BEGIN:VTIMEZONE" . $eol .
-        "TZID:Europe/Amsterdam" . $eol .
-        "BEGIN:DAYLIGHT" . $eol .
-        "TZOFFSETFROM:+0100" . $eol .
-        "TZOFFSETTO:+0200" . $eol .
-        "DTSTART:19810329T020000" . $eol .
-        "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU" . $eol .
-        "TZNAME:CEST" . $eol .
-        "END:DAYLIGHT" . $eol .
-        "BEGIN:STANDARD" . $eol .
-        "TZOFFSETFROM:+0200" . $eol .
-        "TZOFFSETTO:+0100" . $eol .
-        "DTSTART:19961027T030000" . $eol .
-        "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU" . $eol .
-        "TZNAME:CET" . $eol .
-        "END:STANDARD" . $eol .
-        "END:VTIMEZONE" . $eol;
-       
-        // loop over events
+        $vCalendar = new \Eluceo\iCal\Component\Calendar('//Eindhovense Studenten Alpen Club//Agenda//NL');
+
         foreach ($agenda_items as $agenda_item) {
-            $icalObject .=
-            "BEGIN:VEVENT" . $eol .
-            "DTSTART;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->startDate)) . $eol .
-            "DTEND;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->endDate))  . $eol .
-            "DTSTAMP;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->created_at)) . $eol .
-            "SUMMARY:" . $agenda_item->agendaItemTitle->text() . $eol .
-            "DESCRIPTION:" . strip_tags($agenda_item->agendaItemText->text()) . $eol .
-            "UID:" . $agenda_item->id . "@esac.nl" . $eol .
-            "STATUS:CONFIRMED" . $eol .
-            "LAST-MODIFIED;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->updated_at)) . $eol .
-            "END:VEVENT" . $eol;
+            $vEvent = new \Eluceo\iCal\Component\Event();
+            $vEvent
+                ->setDtStart(new \DateTime($agenda_item->startDate))
+                ->setDtEnd(new \DateTime($agenda_item->endDate))
+                ->setSummary($agenda_item->agendaItemTitle->text())
+                ->setDescription(strip_tags($agenda_item->agendaItemText->text()));
+                // TODO: meer info in beschrijving toevoegen zoals inschrijf url of meer info url?
+            $vCalendar->addComponent($vEvent);
         }
- 
-        // close calendar
-        $icalObject .= "END:VCALENDAR";
- 
+
         // Set the headers
-        header('Content-type: text/calendar; charset=utf-8’');
+        header('Content-Type: text/calendar; charset=utf-8');
         header('Content-Disposition: attachment; filename="cal.ics"');
-          
-        echo $icalObject;
+
+        echo $vCalendar->render();
     }
 }

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -11,7 +11,44 @@ class ICalController extends Controller
     public function getAgendaItemsICalObject()
     {
         $agenda_items = AgendaItem::all();
+
+        // Set default timezone
+        $tz = 'Europe/Amsterdam';
+        $dtz = new \DateTimeZone($tz);
+        date_default_timezone_set($tz);
+
+        // Create new calendar
         $vCalendar = new \Eluceo\iCal\Component\Calendar('//Eindhovense Studenten Alpen Club//Agenda//NL');
+
+        // Create timezone rule object for Daylight Saving Time
+        $vTimezoneRuleDst = new \Eluceo\iCal\Component\TimezoneRule(\Eluceo\iCal\Component\TimezoneRule::TYPE_DAYLIGHT);
+        $vTimezoneRuleDst->setTzName('CEST');
+        $vTimezoneRuleDst->setDtStart(new \DateTime('1981-03-29 02:00:00', $dtz));
+        $vTimezoneRuleDst->setTzOffsetFrom('+0100');
+        $vTimezoneRuleDst->setTzOffsetTo('+0200');
+        $dstRecurrenceRule = new \Eluceo\iCal\Property\Event\RecurrenceRule();
+        $dstRecurrenceRule->setFreq(\Eluceo\iCal\Property\Event\RecurrenceRule::FREQ_YEARLY);
+        $dstRecurrenceRule->setByMonth(3);
+        $dstRecurrenceRule->setByDay('-1SU');
+        $vTimezoneRuleDst->setRecurrenceRule($dstRecurrenceRule);
+
+        // Create timezone rule object for Standard Time
+        $vTimezoneRuleStd = new \Eluceo\iCal\Component\TimezoneRule(\Eluceo\iCal\Component\TimezoneRule::TYPE_STANDARD);
+        $vTimezoneRuleStd->setTzName('CET');
+        $vTimezoneRuleStd->setDtStart(new \DateTime('1996-10-27 03:00:00', $dtz));
+        $vTimezoneRuleStd->setTzOffsetFrom('+0200');
+        $vTimezoneRuleStd->setTzOffsetTo('+0100');
+        $stdRecurrenceRule = new \Eluceo\iCal\Property\Event\RecurrenceRule();
+        $stdRecurrenceRule->setFreq(\Eluceo\iCal\Property\Event\RecurrenceRule::FREQ_YEARLY);
+        $stdRecurrenceRule->setByMonth(10);
+        $stdRecurrenceRule->setByDay('-1SU');
+        $vTimezoneRuleStd->setRecurrenceRule($stdRecurrenceRule);
+
+        // Create timezone definition and add rules
+        $vTimezone = new \Eluceo\iCal\Component\Timezone($tz);
+        $vTimezone->addComponent($vTimezoneRuleDst);
+        $vTimezone->addComponent($vTimezoneRuleStd);
+        $vCalendar->setTimezone($vTimezone);
 
         foreach ($agenda_items as $agenda_item) {
             $vEvent = new \Eluceo\iCal\Component\Event();

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -11,7 +11,7 @@ class ICalController extends Controller
     public function getAgendaItemsICalObject()
     {
         $agenda_items = AgendaItem::all();
-        define('ICAL_FORMAT', 'Ymd\THis\Z');
+        define('ICAL_FORMAT', 'Ymd\THis');
  
         $eol = "\r\n";
         $icalObject = "BEGIN:VCALENDAR" . $eol .
@@ -21,20 +21,37 @@ class ICalController extends Controller
         "X-WR-CALNAME:ESAC Agenda" . $eol .
         "DESCRIPTION:Een overzicht van alle ESAC activiteiten" . $eol .
         "X-WR-CALDESC:Een overzicht van alle ESAC activiteiten" . $eol .
-        "PRODID:-//Eindhovense Studenten Alpen Club//Agenda//NL"  . $eol;
+        "PRODID:-//Eindhovense Studenten Alpen Club//Agenda//NL"  . $eol .
+        "BEGIN:VTIMEZONE" . $eol .
+        "TZID:Europe/Amsterdam" . $eol .
+        "BEGIN:DAYLIGHT" . $eol .
+        "TZOFFSETFROM:+0100" . $eol .
+        "TZOFFSETTO:+0200" . $eol .
+        "DTSTART:19810329T020000" . $eol .
+        "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU" . $eol .
+        "TZNAME:CEST" . $eol .
+        "END:DAYLIGHT" . $eol .
+        "BEGIN:STANDARD" . $eol .
+        "TZOFFSETFROM:+0200" . $eol .
+        "TZOFFSETTO:+0100" . $eol .
+        "DTSTART:19961027T030000" . $eol .
+        "RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU" . $eol .
+        "TZNAME:CET" . $eol .
+        "END:STANDARD" . $eol .
+        "END:VTIMEZONE" . $eol;
        
         // loop over events
         foreach ($agenda_items as $agenda_item) {
             $icalObject .=
             "BEGIN:VEVENT" . $eol .
-            "DTSTART:" . date(ICAL_FORMAT, strtotime($agenda_item->startDate)) . $eol .
-            "DTEND:" . date(ICAL_FORMAT, strtotime($agenda_item->endDate))  . $eol .
-            "DTSTAMP:" . date(ICAL_FORMAT, strtotime($agenda_item->created_at)) . $eol .
+            "DTSTART;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->startDate)) . $eol .
+            "DTEND;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->endDate))  . $eol .
+            "DTSTAMP;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->created_at)) . $eol .
             "SUMMARY:" . $agenda_item->agendaItemTitle->text() . $eol .
             "DESCRIPTION:" . strip_tags($agenda_item->agendaItemText->text()) . $eol .
             "UID:" . $agenda_item->id . "@esac.nl" . $eol .
             "STATUS:CONFIRMED" . $eol .
-            "LAST-MODIFIED:" . date(ICAL_FORMAT, strtotime($agenda_item->updated_at)) . $eol .
+            "LAST-MODIFIED;TZID=Europe/Amsterdam:" . date(ICAL_FORMAT, strtotime($agenda_item->updated_at)) . $eol .
             "END:VEVENT" . $eol;
         }
  

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -18,7 +18,11 @@ class ICalController extends Controller
         date_default_timezone_set($tz);
 
         // Create new calendar
-        $vCalendar = new \Eluceo\iCal\Component\Calendar('//Eindhovense Studenten Alpen Club//Agenda//NL');
+        $vCalendar = new \Eluceo\iCal\Component\Calendar('ESAC Agenda');
+        $vCalendar
+            ->setName('ESAC Agenda - esac.nl')
+            ->setDescription("ESAC Agenda - esac.nl")
+            ->setCalendarColor('yellow');
 
         // Create timezone rule object for Daylight Saving Time
         $vTimezoneRuleDst = new \Eluceo\iCal\Component\TimezoneRule(\Eluceo\iCal\Component\TimezoneRule::TYPE_DAYLIGHT);
@@ -56,8 +60,10 @@ class ICalController extends Controller
                 ->setDtStart(new \DateTime($agenda_item->startDate))
                 ->setDtEnd(new \DateTime($agenda_item->endDate))
                 ->setSummary($agenda_item->agendaItemTitle->text())
-                ->setDescription(strip_tags($agenda_item->agendaItemText->text()));
-                // TODO: meer info in beschrijving toevoegen zoals inschrijf url of meer info url?
+                ->setDescription(
+                    html_entity_decode(strip_tags($agenda_item->agendaItemText->text())) .
+                    "\r\n\r\n----------\r\n" .
+                    "Meer informatie: " . url('/agenda/' . $agenda_item->id));
             $vCalendar->addComponent($vEvent);
         }
 

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\AgendaItem;
+use Illuminate\Http\Request;
+use App\repositories\AgendaItemRepository;
+use App\repositories\RepositorieFactory;
+use Illuminate\Support\Facades\App;
+
+class ICalController extends Controller
+{
+    private $_agendaRepository;
+
+    public function __construct(RepositorieFactory $repositorieFactory)
+    {
+        $this->_agendaRepository = $repositorieFactory->getRepositorie(RepositorieFactory::$AGENDAITEMREPOKEY);
+    }
+
+    public function getAgendaItemsICalObject()
+    {
+        $agenda_items = AgendaItem::all();
+        define('ICAL_FORMAT', 'Ymd\THis\Z');
+ 
+        $icalObject = "BEGIN:VCALENDAR
+        VERSION:2.0
+        METHOD:PUBLISH
+        PRODID:-//Eindhovense Studenten Alpen Club//Agenda//NL\n";
+       
+        // loop over events
+        foreach ($agenda_items as $agenda_item) {
+            $icalObject .=
+            "BEGIN:VEVENT
+            DTSTART:" . date(ICAL_FORMAT, strtotime($agenda_item->startDate)) . "
+            DTEND:" . date(ICAL_FORMAT, strtotime($agenda_item->endDate)) . "
+            DTSTAMP:" . date(ICAL_FORMAT, strtotime($agenda_item->created_at)) . "
+            SUMMARY:123 
+            UID:$agenda_item->id
+            STATUS:CONFIRMED
+            LAST-MODIFIED:" . date(ICAL_FORMAT, strtotime($agenda_item->updated_at)) . "
+            END:VEVENT\n";
+        }
+ 
+        // close calendar
+        $icalObject .= "END:VCALENDAR";
+ 
+        // Set the headers
+        header('Content-type: text/calendar');
+        header('Content-Disposition: attachment; filename="cal.ics"');
+       
+        $icalObject = str_replace(' ', '', $icalObject);
+   
+        echo $icalObject;
+    }
+}

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -22,34 +22,38 @@ class ICalController extends Controller
         $agenda_items = AgendaItem::all();
         define('ICAL_FORMAT', 'Ymd\THis\Z');
  
-        $icalObject = "BEGIN:VCALENDAR
-        VERSION:2.0
-        METHOD:PUBLISH
-        PRODID:-//Eindhovense Studenten Alpen Club//Agenda//NL\n";
+        $eol = "\r\n";
+        $icalObject = "BEGIN:VCALENDAR" . $eol .
+        "VERSION:2.0"  . $eol .
+        "METHOD:PUBLISH" . $eol .
+        "NAME:ESAC Agenda" . $eol .
+        "X-WR-CALNAME:ESAC Agenda" . $eol .
+        "DESCRIPTION:Een overzicht van alle ESAC activiteiten" . $eol .
+        "X-WR-CALDESC:Een overzicht van alle ESAC activiteiten" . $eol .
+        "PRODID:-//Eindhovense Studenten Alpen Club//Agenda//NL"  . $eol;
        
         // loop over events
         foreach ($agenda_items as $agenda_item) {
             $icalObject .=
-            "BEGIN:VEVENT
-            DTSTART:" . date(ICAL_FORMAT, strtotime($agenda_item->startDate)) . "
-            DTEND:" . date(ICAL_FORMAT, strtotime($agenda_item->endDate)) . "
-            DTSTAMP:" . date(ICAL_FORMAT, strtotime($agenda_item->created_at)) . "
-            SUMMARY:123 
-            UID:$agenda_item->id
-            STATUS:CONFIRMED
-            LAST-MODIFIED:" . date(ICAL_FORMAT, strtotime($agenda_item->updated_at)) . "
-            END:VEVENT\n";
+            "BEGIN:VEVENT" . $eol .
+            "DTSTART:" . date(ICAL_FORMAT, strtotime($agenda_item->startDate)) . $eol .
+            "DTEND:" . date(ICAL_FORMAT, strtotime($agenda_item->endDate))  . $eol .
+            "DTSTAMP:" . date(ICAL_FORMAT, strtotime($agenda_item->created_at)) . $eol .
+            "SUMMARY:" . $agenda_item->agendaItemTitle->text() . $eol .
+            "DESCRIPTION:" . strip_tags($agenda_item->agendaItemText->text()) . $eol .
+            "UID:" . $agenda_item->id . "@esac.nl" . $eol .
+            "STATUS:CONFIRMED" . $eol .
+            "LAST-MODIFIED:" . date(ICAL_FORMAT, strtotime($agenda_item->updated_at)) . $eol .
+            "END:VEVENT" . $eol;
         }
  
         // close calendar
         $icalObject .= "END:VCALENDAR";
  
         // Set the headers
-        header('Content-type: text/calendar');
+        header('Content-type: text/calendar; charset=utf-8’');
         header('Content-Disposition: attachment; filename="cal.ics"');
-       
-        $icalObject = str_replace(' ', '', $icalObject);
-   
+          
         echo $icalObject;
     }
 }

--- a/app/Http/Controllers/ICalController.php
+++ b/app/Http/Controllers/ICalController.php
@@ -4,19 +4,10 @@ namespace App\Http\Controllers;
 
 use App\AgendaItem;
 use Illuminate\Http\Request;
-use App\repositories\AgendaItemRepository;
-use App\repositories\RepositorieFactory;
 use Illuminate\Support\Facades\App;
 
 class ICalController extends Controller
 {
-    private $_agendaRepository;
-
-    public function __construct(RepositorieFactory $repositorieFactory)
-    {
-        $this->_agendaRepository = $repositorieFactory->getRepositorie(RepositorieFactory::$AGENDAITEMREPOKEY);
-    }
-
     public function getAgendaItemsICalObject()
     {
         $agenda_items = AgendaItem::all();

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "league/flysystem-aws-s3-v3": "~1.0",
         "intervention/image": "^2.4",
         "spatie/laravel-blade-javascript": "^2.2",
-        "doctrine/dbal": "^2.8"
+        "doctrine/dbal": "^2.8",
+        "eluceo/ical": "^0.15.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "815a964c25f0fad2c5fb8421144f0f68",
+    "content-hash": "80ae638648b82ee45a5eb97c561c7c39",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1080,6 +1080,57 @@
             "time": "2018-12-04T22:38:24+00:00"
         },
         {
+            "name": "eluceo/ical",
+            "version": "0.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/markuspoerschke/iCal.git",
+                "reference": "add0ca99aa1f77f134a2e8b071f2ebc22b115139"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/markuspoerschke/iCal/zipball/add0ca99aa1f77f134a2e8b071f2ebc22b115139",
+                "reference": "add0ca99aa1f77f134a2e8b071f2ebc22b115139",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-mbstring": "Massive performance enhancement of line folding"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Eluceo\\iCal\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Poerschke",
+                    "email": "markus@eluceo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The eluceo/iCal package offers a abstraction layer for creating iCalendars. You can easily create iCal files by using PHP object instead of typing your *.ics file by hand. The output will follow RFC 5545 as best as possible.",
+            "homepage": "https://github.com/markuspoerschke/iCal",
+            "keywords": [
+                "calendar",
+                "iCalendar",
+                "ical",
+                "ics",
+                "php calendar"
+            ],
+            "time": "2019-01-13T22:00:58+00:00"
+        },
+        {
             "name": "erusev/parsedown",
             "version": "v1.7.2",
             "source": {
@@ -1124,68 +1175,6 @@
                 "parser"
             ],
             "time": "2019-03-17T17:19:46+00:00"
-        },
-        {
-            "name": "folklore/image",
-            "version": "v0.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/folkloreinc/laravel-image.git",
-                "reference": "44bac7c1029d24306f8eb38fcae04615b6ccf0ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/folkloreinc/laravel-image/zipball/44bac7c1029d24306f8eb38fcae04615b6ccf0ae",
-                "reference": "44bac7c1029d24306f8eb38fcae04615b6ccf0ae",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/support": "~5.0",
-                "imagine/imagine": "0.6.*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "orchestra/testbench": "3.0.*"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "tests/ImageTestCase.php"
-                ],
-                "psr-0": {
-                    "Folklore\\Image\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Folklore",
-                    "email": "info@atelierfolklore.ca",
-                    "homepage": "http://atelierfolklore.ca"
-                },
-                {
-                    "name": "David Mongeau-Petitpas",
-                    "email": "dmp@atelierfolklore.ca",
-                    "homepage": "http://mongo.ca",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Image manipulation library for Laravel 4 based on Imagine and inspired by Croppa for easy url based manipulation",
-            "homepage": "http://github.com/Folkloreatelier/laravel-image",
-            "keywords": [
-                "gd",
-                "gmagick",
-                "image",
-                "imagick",
-                "imagine",
-                "laravel",
-                "thumbnail",
-                "watermark"
-            ],
-            "time": "2015-06-29T21:17:07+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1369,63 +1358,6 @@
                 "url"
             ],
             "time": "2018-12-04T20:46:45+00:00"
-        },
-        {
-            "name": "imagine/imagine",
-            "version": "v0.6.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/avalanche123/Imagine.git",
-                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/149041d2a1b517107bfe270ca2b1a17aa341715d",
-                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "sami/sami": "dev-master"
-            },
-            "suggest": {
-                "ext-gd": "to use the GD implementation",
-                "ext-gmagick": "to use the Gmagick implementation",
-                "ext-imagick": "to use the Imagick implementation"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-develop": "0.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Imagine": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bulat Shakirzyanov",
-                    "email": "mallluhuct@gmail.com",
-                    "homepage": "http://avalanche123.com"
-                }
-            ],
-            "description": "Image processing for PHP 5.3",
-            "homepage": "http://imagine.readthedocs.org/",
-            "keywords": [
-                "drawing",
-                "graphics",
-                "image manipulation",
-                "image processing"
-            ],
-            "time": "2015-09-19T16:54:05+00:00"
         },
         {
             "name": "intervention/image",
@@ -5382,6 +5314,68 @@
             "time": "2018-10-23T09:00:00+00:00"
         },
         {
+            "name": "folklore/image",
+            "version": "v0.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/folkloreinc/laravel-image.git",
+                "reference": "44bac7c1029d24306f8eb38fcae04615b6ccf0ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/folkloreinc/laravel-image/zipball/44bac7c1029d24306f8eb38fcae04615b6ccf0ae",
+                "reference": "44bac7c1029d24306f8eb38fcae04615b6ccf0ae",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.0",
+                "imagine/imagine": "0.6.*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "3.0.*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "tests/ImageTestCase.php"
+                ],
+                "psr-0": {
+                    "Folklore\\Image\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Folklore",
+                    "email": "info@atelierfolklore.ca",
+                    "homepage": "http://atelierfolklore.ca"
+                },
+                {
+                    "name": "David Mongeau-Petitpas",
+                    "email": "dmp@atelierfolklore.ca",
+                    "homepage": "http://mongo.ca",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Image manipulation library for Laravel 4 based on Imagine and inspired by Croppa for easy url based manipulation",
+            "homepage": "http://github.com/Folkloreatelier/laravel-image",
+            "keywords": [
+                "gd",
+                "gmagick",
+                "image",
+                "imagick",
+                "imagine",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "time": "2015-06-29T21:17:07+00:00"
+        },
+        {
             "name": "fzaninotto/faker",
             "version": "v1.8.0",
             "source": {
@@ -5475,6 +5469,63 @@
                 "test"
             ],
             "time": "2015-05-11T14:41:42+00:00"
+        },
+        {
+            "name": "imagine/imagine",
+            "version": "v0.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/avalanche123/Imagine.git",
+                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/149041d2a1b517107bfe270ca2b1a17aa341715d",
+                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "sami/sami": "dev-master"
+            },
+            "suggest": {
+                "ext-gd": "to use the GD implementation",
+                "ext-gmagick": "to use the Gmagick implementation",
+                "ext-imagick": "to use the Imagick implementation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Imagine": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bulat Shakirzyanov",
+                    "email": "mallluhuct@gmail.com",
+                    "homepage": "http://avalanche123.com"
+                }
+            ],
+            "description": "Image processing for PHP 5.3",
+            "homepage": "http://imagine.readthedocs.org/",
+            "keywords": [
+                "drawing",
+                "graphics",
+                "image manipulation",
+                "image processing"
+            ],
+            "time": "2015-09-19T16:54:05+00:00"
         },
         {
             "name": "maximebf/debugbar",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.90.6",
+            "version": "3.90.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "4206c43ef904b24bc63680256e9f425cf32d53a1"
+                "reference": "59ffa2a23553dfc4ed5a4f609377bd1881370ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4206c43ef904b24bc63680256e9f425cf32d53a1",
-                "reference": "4206c43ef904b24bc63680256e9f425cf32d53a1",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/59ffa2a23553dfc4ed5a4f609377bd1881370ad6",
+                "reference": "59ffa2a23553dfc4ed5a4f609377bd1881370ad6",
                 "shasum": ""
             },
             "require": {
@@ -86,20 +86,20 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-03-20T18:10:45+00:00"
+            "time": "2019-03-26T18:29:19+00:00"
         },
         {
             "name": "barryvdh/laravel-ide-helper",
-            "version": "v2.6.1",
+            "version": "v2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/barryvdh/laravel-ide-helper.git",
-                "reference": "725711022be71c6fa2e7bc8f9648bf125986f027"
+                "reference": "39c148ad4273f5b8c49d0a363ddbc0462f1f2eec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/725711022be71c6fa2e7bc8f9648bf125986f027",
-                "reference": "725711022be71c6fa2e7bc8f9648bf125986f027",
+                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/39c148ad4273f5b8c49d0a363ddbc0462f1f2eec",
+                "reference": "39c148ad4273f5b8c49d0a363ddbc0462f1f2eec",
                 "shasum": ""
             },
             "require": {
@@ -160,7 +160,7 @@
                 "phpstorm",
                 "sublime"
             ],
-            "time": "2019-03-05T09:24:51+00:00"
+            "time": "2019-03-26T10:38:22+00:00"
         },
         {
             "name": "barryvdh/reflection-docblock",
@@ -534,24 +534,23 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2"
+                "reference": "a1aa51cf3ab838b83b0867b14e56fc20fbd55b3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
-                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/a1aa51cf3ab838b83b0867b14e56fc20fbd55b3d",
+                "reference": "a1aa51cf3ab838b83b0867b14e56fc20fbd55b3d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0"
+                "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
-                "phpunit/phpunit-mock-objects": "2.3.0 || ^3.0"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 7"
             },
             "type": "library",
             "extra": {
@@ -591,7 +590,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2018-11-01T09:45:54+00:00"
+            "time": "2019-03-26T10:23:26+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -4253,16 +4252,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "82ebae02209c21113908c229e9883c419720738a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/82ebae02209c21113908c229e9883c419720738a",
+                "reference": "82ebae02209c21113908c229e9883c419720738a",
                 "shasum": ""
             },
             "require": {
@@ -4274,7 +4273,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4307,20 +4306,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "97001cfc283484c9691769f51cdf25259037eba2"
+                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/97001cfc283484c9691769f51cdf25259037eba2",
-                "reference": "97001cfc283484c9691769f51cdf25259037eba2",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
+                "reference": "f037ea22acfaee983e271dd9c3b8bb4150bd8ad7",
                 "shasum": ""
             },
             "require": {
@@ -4332,7 +4331,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4366,20 +4365,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T06:26:08+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "89de1d44f2c059b266f22c9cc9124ddc4cd0987a"
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/89de1d44f2c059b266f22c9cc9124ddc4cd0987a",
-                "reference": "89de1d44f2c059b266f22c9cc9124ddc4cd0987a",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/c766e95bec706cdd89903b1eda8afab7d7a6b7af",
+                "reference": "c766e95bec706cdd89903b1eda8afab7d7a6b7af",
                 "shasum": ""
             },
             "require": {
@@ -4428,20 +4427,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-30T16:36:12+00:00"
+            "time": "2019-03-04T13:44:35+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
-                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
+                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
                 "shasum": ""
             },
             "require": {
@@ -4453,7 +4452,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4487,20 +4486,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af"
+                "reference": "f4dddbc5c3471e1b700a147a20ae17cdb72dbe42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/ff208829fe1aa48ab9af356992bb7199fed551af",
-                "reference": "ff208829fe1aa48ab9af356992bb7199fed551af",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/f4dddbc5c3471e1b700a147a20ae17cdb72dbe42",
+                "reference": "f4dddbc5c3471e1b700a147a20ae17cdb72dbe42",
                 "shasum": ""
             },
             "require": {
@@ -4510,7 +4509,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4543,20 +4542,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T06:26:08+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224"
+                "reference": "bc4858fb611bda58719124ca079baff854149c89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/6b88000cdd431cd2e940caa2cb569201f3f84224",
-                "reference": "6b88000cdd431cd2e940caa2cb569201f3f84224",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/bc4858fb611bda58719124ca079baff854149c89",
+                "reference": "bc4858fb611bda58719124ca079baff854149c89",
                 "shasum": ""
             },
             "require": {
@@ -4566,7 +4565,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4602,20 +4601,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T06:26:08+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631"
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
-                "reference": "9050816e2ca34a8e916c3a0ae8b9c2fccf68b631",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/ab50dcf166d5f577978419edd37aa2bb8eabce0c",
+                "reference": "ab50dcf166d5f577978419edd37aa2bb8eabce0c",
                 "shasum": ""
             },
             "require": {
@@ -4624,7 +4623,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4657,20 +4656,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-09-21T13:07:52+00:00"
+            "time": "2019-02-06T07:57:58+00:00"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c"
+                "reference": "b46c6cae28a3106735323f00a0c38eccf2328897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/3b58903eae668d348a7126f999b0da0f2f93611c",
-                "reference": "3b58903eae668d348a7126f999b0da0f2f93611c",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/b46c6cae28a3106735323f00a0c38eccf2328897",
+                "reference": "b46c6cae28a3106735323f00a0c38eccf2328897",
                 "shasum": ""
             },
             "require": {
@@ -4679,7 +4678,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.11-dev"
                 }
             },
             "autoload": {
@@ -4709,7 +4708,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2018-09-30T16:36:12+00:00"
+            "time": "2019-02-08T14:16:39+00:00"
         },
         {
             "name": "symfony/process",
@@ -5200,27 +5199,29 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
-                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "^6.2.3",
-                "squizlabs/php_codesniffer": "^3.0.2"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
@@ -5245,12 +5246,12 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2017-07-22T11:58:36+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "filp/whoops",
@@ -5312,68 +5313,6 @@
                 "whoops"
             ],
             "time": "2018-10-23T09:00:00+00:00"
-        },
-        {
-            "name": "folklore/image",
-            "version": "v0.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/folkloreinc/laravel-image.git",
-                "reference": "44bac7c1029d24306f8eb38fcae04615b6ccf0ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/folkloreinc/laravel-image/zipball/44bac7c1029d24306f8eb38fcae04615b6ccf0ae",
-                "reference": "44bac7c1029d24306f8eb38fcae04615b6ccf0ae",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/support": "~5.0",
-                "imagine/imagine": "0.6.*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "orchestra/testbench": "3.0.*"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "tests/ImageTestCase.php"
-                ],
-                "psr-0": {
-                    "Folklore\\Image\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Folklore",
-                    "email": "info@atelierfolklore.ca",
-                    "homepage": "http://atelierfolklore.ca"
-                },
-                {
-                    "name": "David Mongeau-Petitpas",
-                    "email": "dmp@atelierfolklore.ca",
-                    "homepage": "http://mongo.ca",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Image manipulation library for Laravel 4 based on Imagine and inspired by Croppa for easy url based manipulation",
-            "homepage": "http://github.com/Folkloreatelier/laravel-image",
-            "keywords": [
-                "gd",
-                "gmagick",
-                "image",
-                "imagick",
-                "imagine",
-                "laravel",
-                "thumbnail",
-                "watermark"
-            ],
-            "time": "2015-06-29T21:17:07+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -5469,63 +5408,6 @@
                 "test"
             ],
             "time": "2015-05-11T14:41:42+00:00"
-        },
-        {
-            "name": "imagine/imagine",
-            "version": "v0.6.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/avalanche123/Imagine.git",
-                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/149041d2a1b517107bfe270ca2b1a17aa341715d",
-                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "require-dev": {
-                "sami/sami": "dev-master"
-            },
-            "suggest": {
-                "ext-gd": "to use the GD implementation",
-                "ext-gmagick": "to use the Gmagick implementation",
-                "ext-imagick": "to use the Imagick implementation"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-develop": "0.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Imagine": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bulat Shakirzyanov",
-                    "email": "mallluhuct@gmail.com",
-                    "homepage": "http://avalanche123.com"
-                }
-            ],
-            "description": "Image processing for PHP 5.3",
-            "homepage": "http://imagine.readthedocs.org/",
-            "keywords": [
-                "drawing",
-                "graphics",
-                "image manipulation",
-                "image processing"
-            ],
-            "time": "2015-09-19T16:54:05+00:00"
         },
         {
             "name": "maximebf/debugbar",

--- a/resources/views/beheer/agendaItem/create_edit_image.blade.php
+++ b/resources/views/beheer/agendaItem/create_edit_image.blade.php
@@ -6,7 +6,7 @@
         <span>{{trans("AgendaItems.tumpnailImage")}}</span>
         <div class="form-group mt-2">
             <div class="custom-file">
-              <input type="file" class="custom-file-input" id="thumbnail" name="thumbnail" required="required">
+              <input type="file" class="custom-file-input" id="thumbnail" name="thumbnail" @if($agendaItem->image_url == "")required="required"@endif>
               <label class="custom-file-label" for="customFile">Choose file</label>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,8 +33,6 @@ Route::patch('users/{user}/removeAsActiveMember', 'UserController@removeAsActive
 Route::patch('users/{user}/removeAsPendingMember', 'PendingUserController@removeAsPendingMember');
 Route::patch('users/{user}/approveAsPendingMember', 'PendingUserController@approveAsPendingMember');
 
-
-
 //user certification routes
 Route::get('users/{user}/addCertificate','UserCertificateController@addCertificate');
 Route::get('users/{user}/addCertificate/{certificate}','UserCertificateController@editUserCertificate');
@@ -92,4 +90,5 @@ Route::get('/home','frontEndController@home');
 Route::get('/nieuws','frontEndController@news');
 Route::get('/nieuws/{newsItem}','frontEndController@newsDetailView');
 Route::get('/ledenlijst','frontEndController@memberList');
-Route::get('/{menuItem}','frontEndController@showPage'); 
+Route::get("/ical", "ICalController@getAgendaItemsICalObject");
+Route::get('/{menuItem}','frontEndController@showPage');


### PR DESCRIPTION
Fixes #64 

De kalender is nu beschikbaar onder esac.nl/ical. Om dit te testen kun je met NGROK een tunnel opzetten en die url toevoegen aan je google calendar. Verder even kijken of je de DEBUGBAR uit zet, die insert namelijk wat HTML/CSS in de ical feed. (geen idee of dat problemen oplevert)

Known issues:
- [x] De text van een agenda item kan html bevatten en wordt daarom door strip_tags() gehaald. Alleen zorgt dit ervoor dat er soms spaties tussen zinnen missen. Opzich geen groot probleem lijkt me, maar als iemand een oplossing heeft hoor ik het graag.
- [x] Google calendar lijkt de ical property "X-WR-CALNAME" te negeren. Deze property zou ervoor moeten zorgen dat een agenda automatisch een naam krijgt ipv de url (esac.nl/ical)
- [x] De tijden kloppen op dit moment niet. Er wordt nu standaard uit gegaan van UTC tijden terwijl we natuurlijk niet in die tijdzone zitten. Ben er al een tijdje mee bezig geweest maar kreeg het nog niet werkend.

Op de website lijkt het me een goed idee om een aantal links toe te voegen die het makkelijk maken om de kalendar toe te voegen. Elke kalendar (apple/google/microsoft etc.) heeft zijn eigen URL die we kunnen gebruiken. Voorbeeld iswebcal://esac.nl/ical