### PR TITLE
Fix CSRF token error on login page.

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -4,12 +4,12 @@
 {{trans("auth.login")}}
 @endsection
 
-@component('includes.menu')
-    @slot('navClass', 'bg-dark position-fixed')
-    @slot('navId', '')
-@endcomponent
-
 @section('main')
+    @component('includes.menu')
+        @slot('navClass', 'bg-dark position-fixed')
+        @slot('navId', '')
+    @endcomponent
+
 <section>
     <div class="container">
         <div class="row justify-content-center">


### PR DESCRIPTION
Fixes #99.

The menu was placed outside the html tags on the login page. Apparently this caused javascript to be unable to read the CSRF token from the meta tag. Needs some more testing.