### PR TITLE
update Docker php to 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 
 php:
   - 7.3
+  - 7.4
 
 services:
   - mysql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM php:7.3.12-fpm
+FROM php:7.4.0-fpm
 RUN apt-get update && docker-php-ext-install pdo_mysql && apt install -y zip \
    libzip-dev zip libwebp-dev libjpeg62-turbo-dev libpng-dev libxpm-dev \
-   libfreetype6-dev zlib1g-dev  && docker-php-ext-configure gd --with-gd --with-webp-dir --with-jpeg-dir \
-   --with-png-dir --with-zlib-dir --with-xpm-dir --with-freetype-dir \
-   --enable-gd-native-ttf && docker-php-ext-install gd && rm -rf /var/lib/apt/lists/*
+   libfreetype6-dev zlib1g-dev  && docker-php-ext-configure gd --with-freetype --with-jpeg \
+   && docker-php-ext-install gd && rm -rf /var/lib/apt/lists/*
 
 COPY . /var/www/
 WORKDIR "/var/www/"


### PR DESCRIPTION
ik heb de 7.4 versie getest op de beta server, ziet er allemaal werkend uit,
Ik heb deze change later nodig voor travis deployment, de docker build van travis faalt op php 7.2 en 7.3