### PR TITLE
Docker prod deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -58,6 +58,8 @@ then
   chmod 600 deploy-key
   mv deploy-key ~/.ssh/id_rsa
 
+  ssh deploy@beta.esac.nl './update.sh website 0.0.'$TRAVIS_BUILD_NUMBER$SNAPSHOTTAG '"'$AUTHOR_NAME'"' '"'$COMMIT_MSG'"' '"'$COMMMIT_DATE'"' '"'$TRAVIS_PULL_REQUEST_BRANCH'"'
+  DEPLOYSTATUS=$?
   ssh ic@esac.nl './update.sh website 0.0.'$TRAVIS_BUILD_NUMBER$SNAPSHOTTAG '"'$AUTHOR_NAME'"' '"'$COMMIT_MSG'"' '"'$COMMMIT_DATE'"' '"'$TRAVIS_PULL_REQUEST_BRANCH'"'
   DEPLOYSTATUS=$?
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,9 +2,7 @@
 #see the server config branch for the contents of the update.sh script
 
 #setup ssh private key
-echo $private_key_staging_server | base64 --decode > deploy-key
-chmod 600 deploy-key
-mv deploy-key ~/.ssh/id_rsa
+
 
 
 SNAPSHOTTAG=''
@@ -30,6 +28,13 @@ COMMMIT_DATE="$(git log -1 $TRAVIS_COMMIT --pretty="%cD")"
 #The variable  $$TRAVIS_PULL_REQUEST_BRANCH is  empty when the run is not a PR,  so it will deploy to beta.esac.nl when there is a PR
 if [[ $TRAVIS_PULL_REQUEST_BRANCH != '' ]]
 then
+  echo 'deploying to staging'
+
+  #creating private key
+  echo $private_key_staging_server | base64 --decode > deploy-key
+  chmod 600 deploy-key
+  mv deploy-key ~/.ssh/id_rsa
+
   ssh deploy@beta.esac.nl './update.sh website 0.0.'$TRAVIS_BUILD_NUMBER$SNAPSHOTTAG '"'$AUTHOR_NAME'"' '"'$COMMIT_MSG'"' '"'$COMMMIT_DATE'"' '"'$TRAVIS_PULL_REQUEST_BRANCH'"'
   DEPLOYSTATUS=$?
   lhci autorun --upload.serverBaseUrl="http://beta.esac.nl:9001" --upload.token="$LHCI_TOKEN"
@@ -47,6 +52,15 @@ then
 elif [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST_BRANCH == '' ]]
 then
   echo 'deploy to master'
+
+  #creating private key
+  echo $private_key_productie_server | base64 --decode > deploy-key
+  chmod 600 deploy-key
+  mv deploy-key ~/.ssh/id_rsa
+
+  ssh ic@esac.nl './update.sh website 0.0.'$TRAVIS_BUILD_NUMBER$SNAPSHOTTAG '"'$AUTHOR_NAME'"' '"'$COMMIT_MSG'"' '"'$COMMMIT_DATE'"' '"'$TRAVIS_PULL_REQUEST_BRANCH'"'
+  DEPLOYSTATUS=$?
+
   lhci autorun --upload.serverBaseUrl="http://beta.esac.nl:9001" --upload.token="$LHCI_TOKEN"
 #  ssh deploy@esac.nl './update.sh' #account is not setup yet
 fi


### PR DESCRIPTION
private key toegevoegd om naar productie te deployen, 
dit gebeurd met een nieuwe private key die aangemaakt is voor ic@esac.nl die ook in de ssh word gebruikt. De key kan alleen gebruikt worden in de master branch.

De setup van het gebruik van de private keys/deployment is beschreven in de andere repo(server_setup), voor als  op een later moment keys opnieuw aangemaakt moeten worden, de key is opgeslagen als een base64 string