### PR TITLE
Signup route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,7 @@ Route::get('/bibliotheek','frontEndController@library');
 Route::get('/agenda','frontEndController@agenda');
 Route::get('/agenda/{agendaItem}','frontEndController@agendaDetailView')->name('agenda.detail');
 Route::get('/lidworden','frontEndController@publicSubscribe');
+Route::get('/signup','frontEndController@publicSubscribe');
 Route::get('/home','frontEndController@home');
 Route::get('/nieuws','frontEndController@news');
 Route::get('/nieuws/{newsItem}','frontEndController@newsDetailView');


### PR DESCRIPTION
As the signup route is often printed on flyers etc, and those always have an English version as well, it would be nice to have an English URL for signup together with a Dutch one.
This PR adds a /signup route, linking to the same page as /lidworden.