### PR TITLE
Fix/#273/#273 user deletion with intro packages

### DIFF
--- a/app/Http/Controllers/PendingUserController.php
+++ b/app/Http/Controllers/PendingUserController.php
@@ -49,6 +49,11 @@ class PendingUserController extends Controller
     }
 
     public function removeAsPendingMember(Request $request, User $user){
+        $registration_info = $user->registrationInfo();
+        if(!is_null($registration_info)){
+            $registration_info->delete();
+        }
+        
         $user->removeAsPendingMember();
 
         return redirect('users/pending_members');


### PR DESCRIPTION
The problem seemed to be that User was being deleted, while the UserRegistrationInfo still existed. This is solved by removing the UserRegistrationInfo (if it exists) and then removing the user.

New pull request because the GitHub actions workflow was still old in the old pull request and everything went to shit when I wanted to rebase.