### PR TITLE
Removed SoftDeletes from UserRegistrationInfo, as this caused errors when deleting a pending user when intropackages are enabled.

### DIFF
--- a/app/Models/User/UserRegistrationInfo.php
+++ b/app/Models/User/UserRegistrationInfo.php
@@ -8,8 +8,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class UserRegistrationInfo extends Model
 {
-    use SoftDeletes;
-
     protected $table = 'user_registration_info';
 
     protected $fillable = [


### PR DESCRIPTION
If we want to use SoftDeletes on UserRegistrationInfo's, easiest fix is likely using SoftDeletes on Users. I don't think this is desirable with GDPR and all. If we really want UserRegistationInfo to be saved upon rejecting a member, we will need to look into a solution.