### PR TITLE
Show user `created_at` attributes in Excel export

### DIFF
--- a/app/Exports/UsersExport.php
+++ b/app/Exports/UsersExport.php
@@ -26,7 +26,7 @@ class UsersExport implements FromCollection, WithTitle, WithHeadings, ShouldAuto
         $activeUsers = $this->userRepository->getCurrentUsers(['*'],['certificates']);
         $exportData = [];
         foreach ($activeUsers as $user){
-            $user->makeHidden(['created_at', 'updated_at', 'lid_af', 'pending_user']);
+            $user->makeHidden(['updated_at', 'lid_af', 'pending_user']);
             $data = $user->toArray();
             $data['certificates'] = $user->getCertificationsAbbreviations();
             array_push($exportData,$data);
@@ -74,7 +74,8 @@ class UsersExport implements FromCollection, WithTitle, WithHeadings, ShouldAuto
             trans('user.BIC'),
             trans('user.incasso'),
             trans('user.remark'),
-            trans('user.certificates')
+            trans('user.created_at'),
+            trans('user.certificates'),
         ];
     }
 }


### PR DESCRIPTION
When exporting users to Excel, the `created_at` attribute was hidden and, thus, not included in the export. This PR ensures that the user creation timestamps are included in the export again.

NB: there were already language texts in both NL and EN for the `user.created_at` key, so the header is displayed correctly in the export for both locales. 