### PR TITLE
Addition of an NSAC emergency info role

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -28,9 +28,9 @@ class UserController extends Controller
     {
         $this->middleware('auth');
         // The edit, update, and show methods check the authorization themselves, so we don't apply a role middleware there.
-        // Only the index method is accessible by both Administrators and Certificate admins, so we apply a different middleware there.
+        // Only the index method is accessible by both Administrators, Certificate admins and NSAC emergency info users, so we apply a different middleware there.
         $this->middleware('authorize:'.\Config::get('constants.Administrator'))->except(['edit', 'update', 'show', 'index']);
-        $this->middleware('authorize:'.\Config::get('constants.Administrator') .',' . \Config::get('constants.Certificate_administrator'))->only(['index']);
+        $this->middleware('authorize:'.\Config::get('constants.Administrator') .',' . \Config::get('constants.Certificate_administrator') .',' .\Config::get('constants.NSAC_emergency_info_administrator'))->only(['index']);
         $this->_userRepository = $repositoryFactory->getRepositorie(RepositorieFactory::$USERREPOKEY);
     }
 
@@ -75,7 +75,7 @@ class UserController extends Controller
     }
 
     public function show(Request $request, User $user){
-        if(Auth::user()->id != $user->id && !Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator'))){
+        if(Auth::user()->id != $user->id && !Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator'),Config::get('constants.NSAC_emergency_info_administrator'))){
             abort(403, trans('validation.Unauthorized'));
         }
         return view('beheer.user.show', compact('user'));

--- a/app/Http/Middleware/Authorize.php
+++ b/app/Http/Middleware/Authorize.php
@@ -14,9 +14,9 @@ class Authorize
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next, $role,$role2 = "-1")
+    public function handle($request, Closure $next, $role,$role2,$role3 = "-1")
     {
-        if(Auth::user()->hasRole($role,$role2)){
+        if(Auth::user()->hasRole($role,$role2,$role3)){
             return $next($request);
         } else {
             abort(403, trans('validation.Unauthorized'));

--- a/app/Http/Middleware/Authorize.php
+++ b/app/Http/Middleware/Authorize.php
@@ -14,7 +14,7 @@ class Authorize
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next, $role,$role2,$role3 = "-1")
+    public function handle($request, Closure $next, $role,$role2="-1",$role3 = "-1")
     {
         if(Auth::user()->hasRole($role,$role2,$role3)){
             return $next($request);

--- a/config/constants.php
+++ b/config/constants.php
@@ -10,6 +10,7 @@ return [
     "Administrator" => 1,
     "Content_administrator" => 2,
     "Activity_administrator" => 3,
-    "Certificate_administrator" => 4
-
+    "Certificate_administrator" => 4,
+    "NSAC_emegency_info_administrator" => 5
+    
 ];

--- a/config/constants.php
+++ b/config/constants.php
@@ -11,6 +11,6 @@ return [
     "Content_administrator" => 2,
     "Activity_administrator" => 3,
     "Certificate_administrator" => 4,
-    "NSAC_emegency_info_administrator" => 5
+    "NSAC_emergency_info_administrator" => 5
     
 ];

--- a/database/seeders/RolTableSeeder.php
+++ b/database/seeders/RolTableSeeder.php
@@ -30,5 +30,9 @@ class RolTableSeeder extends Seeder
         $text->save();
         $rol  = new \App\Rol(['name' => $text->id]);
         $rol->save();
+        $text = new \App\Text(['NL_text' => 'NSAC noodgegevens beheerder', 'EN_text' => 'NSAC emergency info administrator']);
+        $text->save();
+        $rol  = new \App\Rol(['name' => $text->id]);
+        $rol->save();
     }
 }

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -46,6 +46,39 @@ class UsersTableSeeder extends Seeder
         //add rol
         $user->roles()->attach(['1','2','3']); //id for Administrator
         $user->save();
+        
+        //inserting test data
+        $user = new \App\User();
+        $user->email = "test@nsac.nl";
+        $user->password = bcrypt("test");
+        $user->firstname = "Board";
+        $user->preposition = "of";
+        $user->lastname = "NSAC";
+        $user->street = "Kerkstraat";
+        $user->houseNumber = 34;
+        $user->city = "test";
+        $user->zipcode = "5301jh";
+        $user->country = "NL";
+        $user->phonenumber = "123456789";
+        $user->phonenumber_alt = "987654321";
+        $user->emergencyNumber = "147258369";
+        $user->emergencyHouseNumber = "19";
+        $user->emergencystreet = "Kerk straat";
+        $user->emergencycity = "Eindhoven";
+        $user->emergencyzipcode = "3633IK";
+        $user->emergencycountry = "NL";
+        $user->birthDay = Carbon::now()->subYear(20);
+        $user->gender = "man";
+        $user->kind_of_member = "relationship"; //not 100% sure if this is the correct kind of member for nsac board
+        $user->IBAN = "NL55 RABO 0107331020";
+        $user->BIC = "";
+        $user->incasso = false;
+        $user->remark = "Ik ben een test NSAC bestuur gebruiker";
+        $user->save();
+
+        //add rol
+        $user->roles()->attach(['5']); //id for nsac emergency info access
+        $user->save();
 
         //inserting test data
         $user = new \App\User();

--- a/resources/views/beheer/user/show.blade.php
+++ b/resources/views/beheer/user/show.blade.php
@@ -99,7 +99,7 @@
                 @endif
             </ul>
             
-            @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id || \Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.NSAC_emegency_info_administrator')))
+            @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id || \Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.NSAC_emergency_info_administrator')))
             <div class="tab-content space-sm">
                 @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade show active" id="tab1-content" role="tabpanel" aria-labelledby="tab1-content">

--- a/resources/views/beheer/user/show.blade.php
+++ b/resources/views/beheer/user/show.blade.php
@@ -74,34 +74,39 @@
         </div>
         <div class="card-body">
             <ul class="nav nav-tabs" id="myTab" role="tablist">
-                <li class="nav-item">
-                    <a class="nav-link active" id="tab1" data-toggle="tab" href="#tab1-content" role="tab" aria-controls="general" aria-selected="true">{{trans('user.personal')}}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" id="tab2" data-toggle="tab" href="#tab2-content" role="tab" aria-controls="billing" aria-selected="false">{{trans('user.financial')}}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" id="tab3" data-toggle="tab" href="#tab3-content" role="tab" aria-controls="security" aria-selected="false">{{trans('user.emergencyInfo')}}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" id="tab3" data-toggle="tab" href="#rols" role="tab" aria-controls="security" aria-selected="false">{{trans('user.rols')}}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" id="tab3" data-toggle="tab" href="#certifications" role="tab" aria-controls="security" aria-selected="false">{{trans('certificate.certificates') }}</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" id="tab3" data-toggle="tab" href="#registrations" role="tab" aria-controls="security" aria-selected="false">{{trans('user.registrations') }}</a>
-                </li>
-                @if($user->registrationInfo !== null)
+                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.NSAC_emergency_info_administrator')) && \Illuminate\Support\Facades\Auth::user()->id !== $user->id)
                     <li class="nav-item">
-                        <a class="nav-link" data-toggle="tab" href="#registration_info" role="tab" aria-controls="security" aria-selected="false">{{trans('user.registrationInfo') }}</a>
+                        <a class="nav-link active" id="tab3" data-toggle="tab" href="#tab3-content" role="tab" aria-controls="security" aria-selected="true">{{trans('user.emergencyInfo')}}</a>
                     </li>
+                @else
+                    <li class="nav-item">
+                        <a class="nav-link active" id="tab1" data-toggle="tab" href="#tab1-content" role="tab" aria-controls="general" aria-selected="true">{{trans('user.personal')}}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="tab2" data-toggle="tab" href="#tab2-content" role="tab" aria-controls="billing" aria-selected="false">{{trans('user.financial')}}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="tab3" data-toggle="tab" href="#tab3-content" role="tab" aria-controls="security" aria-selected="false">{{trans('user.emergencyInfo')}}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="tab3" data-toggle="tab" href="#rols" role="tab" aria-controls="security" aria-selected="false">{{trans('user.rols')}}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="tab3" data-toggle="tab" href="#certifications" role="tab" aria-controls="security" aria-selected="false">{{trans('certificate.certificates') }}</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" id="tab3" data-toggle="tab" href="#registrations" role="tab" aria-controls="security" aria-selected="false">{{trans('user.registrations') }}</a>
+                    </li>
+                    @if($user->registrationInfo !== null)
+                        <li class="nav-item">
+                            <a class="nav-link" data-toggle="tab" href="#registration_info" role="tab" aria-controls="security" aria-selected="false">{{trans('user.registrationInfo') }}</a>
+                        </li>
+                    @endif
                 @endif
             </ul>
             
-            @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id || \Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.NSAC_emergency_info_administrator')))
+            @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
             <div class="tab-content space-sm">
-                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade show active" id="tab1-content" role="tabpanel" aria-labelledby="tab1-content">
                     <table class="table table-striped" style="width:100%">
                         <tr>
@@ -182,8 +187,6 @@
                         </tr>
                     </table>
                 </div>
-                @endif
-                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="tab2-content" role="tabpanel" aria-labelledby="tab2-content">
                     <table class="table table-striped" style="width:100%">
                         <tr>
@@ -200,7 +203,6 @@
                         </tr>
                     </table>
                 </div>
-                @endif
                 {{-- This tab should be visible to the NSAC emergency info role --}}
                 <div class="tab-pane fade" id="tab3-content" role="tabpanel" aria-labelledby="tab3-content">
                     <table class="table table-striped" style="width:100%">
@@ -230,7 +232,6 @@
                         </tr>
                     </table>
                 </div>
-                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="rols" role="tabpanel" aria-labelledby="tab3-content">
                     <table class="table table-striped" style="width:100%">
                         @if(count($user->roles) > 0)
@@ -246,9 +247,7 @@
                         @endif
                     </table>
                 </div>
-                @endif
             {{-- @endif --}}
-                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="certifications" role="tabpanel" aria-labelledby="tab3-content">
                     <table class="table table-striped" style="width:100%">
                         <thead>
@@ -298,8 +297,6 @@
                         </tbody>
                     </table>
                 </div>
-                @endif
-                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="registrations" role="tabpanel" aria-labelledby="registrations">
                     <table class="table table-striped" style="width:100%" id="registrations_table">
                         <thead>
@@ -319,13 +316,43 @@
                         </tbody>
                     </table>
                 </div>
-                @endif
                 
                 @if($user->registrationInfo !== null && (\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id))
                     <div class="tab-pane fade" id="registration_info" role="tabpanel">
                         @include('beheer.user.partials.intro-info')
                     </div>
                 @endif
+            </div>
+            @elseif(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.NSAC_emergency_info_administrator')) && \Illuminate\Support\Facades\Auth::user()->id !== $user->id)
+            <div class="tab-content space-sm">
+                <div class="tab-pane fade show active" id="tab3-content" role="tabpanel" aria-labelledby="tab3-content">
+                    <table class="table table-striped" style="width:100%">
+                        <tr>
+                            <td>{{trans('user.emergencystreet')}}</td>
+                            <td>{{$user->emergencystreet}}</td>
+                        </tr>
+                        <tr>
+                            <td>{{trans('user.emergencyHouseNumber')}}</td>
+                            <td>{{$user->emergencyHouseNumber}}</td>
+                        </tr>
+                        <tr>
+                            <td>{{trans('user.emergencyzipcode')}}</td>
+                            <td>{{$user->emergencyzipcode}}</td>
+                        </tr>
+                        <tr>
+                            <td>{{trans('user.emergencycity')}}</td>
+                            <td>{{$user->emergencycity}}</td>
+                        </tr>
+                        <tr>
+                            <td>{{trans('user.emergencycountry')}}</td>
+                            <td>{{trans('countries.' . $user->emergencycountry)}}</td>
+                        </tr>
+                        <tr>
+                            <td>{{trans('user.emergencyNumber')}}</td>
+                            <td>{{$user->emergencyNumber}}</td>
+                        </tr>
+                    </table>
+                </div>
             </div>
             @endif
         </div>

--- a/resources/views/beheer/user/show.blade.php
+++ b/resources/views/beheer/user/show.blade.php
@@ -37,10 +37,14 @@
                         <button type="submit" class="btn btn-success"><em class="ion-plus"></em> {{trans("user.makeActiveMember")}}</button>
                     {{ Form::close() }}
                 @endif
+                
+                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <a href="{{url('/users/'.$user->id . '/edit' )}}" class="btn btn-primary">
                     <span title="{{trans("menu.edit")}}" class="ion-edit" aria-hidden="true"></span>
                     {{trans("menu.edit")}}
                 </a>
+                @endif
+                
                 @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator')))
                     <a href="{{url('/users/'.$user->id . '/addCertificate' )}}" class="btn btn-primary">
                         <span title="{{trans("user.addCertificate")}}" class="ion-plus" aria-hidden="true"></span>
@@ -94,8 +98,10 @@
                     </li>
                 @endif
             </ul>
-            @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
+            
+            @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id || \Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.NSAC_emegency_info_administrator')))
             <div class="tab-content space-sm">
+                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade show active" id="tab1-content" role="tabpanel" aria-labelledby="tab1-content">
                     <table class="table table-striped" style="width:100%">
                         <tr>
@@ -176,6 +182,8 @@
                         </tr>
                     </table>
                 </div>
+                @endif
+                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="tab2-content" role="tabpanel" aria-labelledby="tab2-content">
                     <table class="table table-striped" style="width:100%">
                         <tr>
@@ -192,6 +200,8 @@
                         </tr>
                     </table>
                 </div>
+                @endif
+                {{-- This tab should be visible to the NSAC emergency info role --}}
                 <div class="tab-pane fade" id="tab3-content" role="tabpanel" aria-labelledby="tab3-content">
                     <table class="table table-striped" style="width:100%">
                         <tr>
@@ -220,6 +230,7 @@
                         </tr>
                     </table>
                 </div>
+                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="rols" role="tabpanel" aria-labelledby="tab3-content">
                     <table class="table table-striped" style="width:100%">
                         @if(count($user->roles) > 0)
@@ -236,6 +247,8 @@
                     </table>
                 </div>
                 @endif
+            {{-- @endif --}}
+                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="certifications" role="tabpanel" aria-labelledby="tab3-content">
                     <table class="table table-striped" style="width:100%">
                         <thead>
@@ -285,6 +298,8 @@
                         </tbody>
                     </table>
                 </div>
+                @endif
+                @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id)
                 <div class="tab-pane fade" id="registrations" role="tabpanel" aria-labelledby="registrations">
                     <table class="table table-striped" style="width:100%" id="registrations_table">
                         <thead>
@@ -304,12 +319,15 @@
                         </tbody>
                     </table>
                 </div>
-                @if($user->registrationInfo !== null)
+                @endif
+                
+                @if($user->registrationInfo !== null && (\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator')) || \Illuminate\Support\Facades\Auth::user()->id === $user->id))
                     <div class="tab-pane fade" id="registration_info" role="tabpanel">
                         @include('beheer.user.partials.intro-info')
                     </div>
                 @endif
             </div>
+            @endif
         </div>
     </div>
 @endsection

--- a/resources/views/layouts/beheer.blade.php
+++ b/resources/views/layouts/beheer.blade.php
@@ -40,7 +40,7 @@
                             </a>
                         </li>
                     @else
-                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Activity_administrator'),Config::get('constants.Content_administrator'),Config::get('constants.Certificate_administrator')))
+                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Activity_administrator'),Config::get('constants.Content_administrator'),Config::get('constants.Certificate_administrator'),Config::get('constants.NSAC_emegency_info_administrator')))
                             <hr class="my-3">
 
                             <li class="nav-item active">
@@ -54,7 +54,7 @@
                                 </a>
                             </li>
                         @endif
-                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator')))
+                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator'),Config::get('constants.NSAC_emegency_info_administrator')))
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     {{trans("menu.leden")}}
@@ -66,7 +66,9 @@
                                         <a class="dropdown-item" href="{{ url('users/pending_members') }}">{{trans("user.pending_members")}}</a>
                                         <a class="dropdown-item" href="{{ url('rols') }}">{{trans("menu.rols")}}</a>
                                     @endif
-                                    <a class="dropdown-item" href="{{ url('certificates') }}">{{trans("menu.certificate")}}</a>
+                                    @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator')))
+                                        <a class="dropdown-item" href="{{ url('certificates') }}">{{trans("menu.certificate")}}</a>
+                                    @endif
                                 </div>
                             </li>
                         @endif

--- a/resources/views/layouts/beheer.blade.php
+++ b/resources/views/layouts/beheer.blade.php
@@ -40,7 +40,7 @@
                             </a>
                         </li>
                     @else
-                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Activity_administrator'),Config::get('constants.Content_administrator'),Config::get('constants.Certificate_administrator'),Config::get('constants.NSAC_emegency_info_administrator')))
+                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Activity_administrator'),Config::get('constants.Content_administrator'),Config::get('constants.Certificate_administrator'),Config::get('constants.NSAC_emergency_info_administrator')))
                             <hr class="my-3">
 
                             <li class="nav-item active">
@@ -54,7 +54,7 @@
                                 </a>
                             </li>
                         @endif
-                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator'),Config::get('constants.NSAC_emegency_info_administrator')))
+                        @if(\Illuminate\Support\Facades\Auth::user()->hasRole(Config::get('constants.Administrator'),Config::get('constants.Certificate_administrator'),Config::get('constants.NSAC_emergency_info_administrator')))
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     {{trans("menu.leden")}}


### PR DESCRIPTION
Adds an extra role which allows a member to only see the emergency info of members in the administrator dashboard.