### PR TITLE
Set codecov patch status checks to `informational`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @esac-ic/code-owners

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    groups:
+      prod-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "16:00"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,11 @@ env:
   DB_DATABASE: esac
   DB_USERNAME: mysql
   DB_PASSWORD: mysql
+  HAS_CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN != '' }}
 
 jobs:
-  laravel-tests:
+  tests:
+    name: Build front-end & run tests
     runs-on: ubuntu-latest
     environment: Build
     steps:
@@ -34,12 +36,6 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
-
-    - name: Docker Login
-      uses: docker/login-action@v3
-      with:
-        username: esacci
-        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -85,22 +81,37 @@ jobs:
     - name: Execute tests (Unit and Feature tests) via PHPUnit
       run: vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.xml
 
-    - name: Upload to codecov
+    - name: Upload to Codecov
       uses: codecov/codecov-action@v3
+      if: env.HAS_CODECOV_TOKEN
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
         fail_ci_if_error: true
 
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v5
+  publish:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    environment: Build
+    needs: tests
+    if: github.secret_source == 'Actions' || github.secret_source == 'Dependabot'
+    steps:
+    - name: Docker Login
+      uses: docker/login-action@v3
+      with:
+        username: esacci
+        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v6
       with:
         push: true
         tags: esac/website:${{ github.run_number }}
 
   deploy:
+    name: Deploy to production
     runs-on: ubuntu-latest
-    needs: laravel-tests
+    needs: publish
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
     - name: Deploy via SSH

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,4 +7,4 @@ coverage:
 
     patch: # Applies to the contents of a single PR or commit only.
       default:
-        informational: false
+        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,10 @@
 coverage:
   status:
-    project:  # Applies to the entire project
+    project: # Applies to the entire project
       default:
         target: auto
         threshold: 25%  # Allows coverage to drop by up to 30% without failing
 
-    patch:  # Applies only to the changes in the pull request
+    patch: # Applies to the contents of a single PR or commit only.
       default:
-        target: auto
-        threshold: 25%  # Allows coverage to drop by up to 30% without failing
+        informational: false


### PR DESCRIPTION
* This _should_ make the status check not show up as a fail anymore in PRs.
* Added [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) file, for instance to be used # in rulesets.
* Dependabot config that should ignore updates in `major` version of packages.
* Add compatibility with Dependabot PRs in [the Github Actions CI Workflow](https://github.com/esac-ic/esac.nl/actions/runs/12040143223).