### PR TITLE
fix(docker): resolve php-fpm startup error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,19 +22,23 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-enable opcache \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
 # Copy files and set the working directory
-COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY . /var/www/
 WORKDIR "/var/www/"
 
-# Install Composer, PHP dependencies, and NPM dependencies
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && composer install --no-dev \
+# Install PHP dependencies, and NPM dependencies
+RUN composer install --no-dev \
     && npm install \
     && npm run prod
 
+# Copy opcache.ini after builds to prevent CLI opcache issues on arm64
+COPY opcache.ini /usr/local/etc/php/conf.d/opcache.ini
+
 # Configure application
-RUN echo "listen = web:9000" >> /usr/local/etc/php-fpm.d/www.conf \
+RUN echo "listen = 0.0.0.0:9000" >> /usr/local/etc/php-fpm.d/www.conf \
     && php artisan storage:link \
     && php artisan config:clear \
     && cp -R public/. public_backup/ \


### PR DESCRIPTION
## Proposed changes

This PR aims to fix the production container startup error in the current master version by updating the Dockerfile startup configuration.

- Install Composer before copying and building the application.
- Install application dependencies before enabling the custom opcache configuration to avoid CLI opcache issues on arm64.
- Configure PHP-FPM to listen on `0.0.0.0:9000` instead of `web:9000`.

The latter being the main reason for the error. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Documentation update.
- [ ] Other.

## Functional review

### Instructions

- [ ] Step 1: Checkout the branch `bugfix/docker-run-php-fpm`.
- [ ] Step 2: Build the production Docker image.
- [ ] Step 3: Start the container and verify PHP-FPM listens on port 9000 without startup errors.

### Updated components

- [x] Docker container configuration.
- [ ] CI/CD (or DevOps).
- [ ] Documentation.
- [ ] Other: _Please specify_.

## Further comments

In the docker-compose setup, we run a service named `app` for the image built for this repository and a service named `web` for an nginx container acting as a reverse FastCGI proxy. Thus, the application was trying to bind the FPM listener to the IP address of a different container. 
