### PR TITLE
Bugfix/fix orphaned certificate pivot rows

### DIFF
--- a/app/Certificate.php
+++ b/app/Certificate.php
@@ -12,4 +12,14 @@ class Certificate extends Model
         'name',
         'abbreviation',
     ];
+
+    public static function booted(){
+        static::deleted(function($certificate){
+            $certificate->users()->detach();
+        });
+    }
+
+    public function users(){
+        return $this->belongsToMany(User::class);
+    }
 }

--- a/database/migrations/2026_06_02_182050_cleanup_orphaned_certificate_pivot_rows.php
+++ b/database/migrations/2026_06_02_182050_cleanup_orphaned_certificate_pivot_rows.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('certificate_user')->
+            where('certificate_id', function ($query) {
+                $query->select('id')->from('certificates')->whereNotNull('deleted_at');
+        })->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
Add migration to cleanup old "ghost" pivot entries. Then add logic to detach users from certificates when the certificate gets deleted.