### PR TITLE
Option to hide agenda items

### DIFF
--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -49,32 +49,32 @@ class AgendaController extends Controller
         if (Auth::guest() || $request->input('beheer') != true) {
             $agendaItemQuery->where('hidden', 0)
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
+                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(7));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
+                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(14));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
+                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(21));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
+                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(28));
                 });
         }
         else if (!Auth::user()->hasRole(Config::get('constants.Administrator'))) {
             $agendaItemQuery->where('hidden', 0)
                 ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden on beheer page
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
+                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(7));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
+                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(14));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
+                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(21));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
+                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(28));
                 });
         }
 

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -93,6 +93,7 @@ class AgendaController extends Controller
                     'application_form_id' => $agendaItem->application_form_id,
                     'amountOfPeopleRegisterd' => count($registeredUserIds),
                     'currentUserSignedUp' => $currentUserSignedUp,
+                    'hidden' => $agendaItem->hidden,
                 ];
             });
 

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -45,8 +45,8 @@ class AgendaController extends Controller
             $agendaItemQuery->where('startDate', '<=', $endDate);
         }
         
-        # If user is not an administrator, filter out the hidden agenda items
-        if (Auth::guest()) {
+        # If user is not an administrator, or not on the beheer page, filter out the hidden agenda items
+        if (Auth::guest() || $request->input('beheer') != true) {
             $agendaItemQuery->where('hidden', 0)
                 ->orWhere(function ($query) {
                     $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
@@ -63,7 +63,7 @@ class AgendaController extends Controller
         }
         else if (!Auth::user()->hasRole(Config::get('constants.Administrator'))) {
             $agendaItemQuery->where('hidden', 0)
-                ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden
+                ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden on beheer page
                 ->orWhere(function ($query) {
                     $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
                 })

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -47,7 +47,7 @@ class AgendaController extends Controller
         
         # If user is not an administrator, filter out the hidden agenda items
         if (Auth::user() == null || !Auth::user()->hasBackendRights()) {
-            $agendaItemQuery->where('hidden', 0)
+            $agendaItemQuery->where('hidden', '<>', 404)->where('hidden', 0)
                 ->orWhere(function ($query) {
                     $query->where('hidden', 1)->where('startDate', '<', Carbon::now()->addDays(8));
                 })

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -46,7 +46,22 @@ class AgendaController extends Controller
         }
         
         # If user is not an administrator, filter out the hidden agenda items
-        if (Auth::guest() || !Auth::user()->hasRole(Config::get('constants.Administrator'))) {
+        if (Auth::guest()) {
+            $agendaItemQuery->where('hidden', 0)
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
+                });
+        }
+        else if (!Auth::user()->hasRole(Config::get('constants.Administrator'))) {
             $agendaItemQuery->where('hidden', 0)
                 ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden
                 ->orWhere(function ($query) {

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -9,6 +9,7 @@ use App\Services\AgendaApplicationFormService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
 
 class AgendaController extends Controller
 {
@@ -43,15 +44,24 @@ class AgendaController extends Controller
             $endDate = Carbon::createFromFormat('d-m-Y', $endDate)->endOfDay();
             $agendaItemQuery->where('startDate', '<=', $endDate);
         }
+        
+        # If user is not an administrator, filter out the hidden agenda items
+        if (Auth::user() == null || !Auth::user()->hasBackendRights()) {
+            $agendaItemQuery->where('hidden', 0)
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 1)->where('startDate', '<', Carbon::now()->addDays(8));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 2)->where('startDate', '<', Carbon::now()->addDays(15));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 3)->where('startDate', '<', Carbon::now()->addDays(22));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 4)->where('startDate', '<', Carbon::now()->addDays(29));
+                });
+        }
 
-        // if (!Auth::user()->hasRole(Config::get('constants.Administrator'))) {
-        //     $today = Carbon::createFromFormat('d-m-Y', Carbon::now())->startOfDay();
-        //     $agendaItemQuery->where(function ($query) use ($today) {
-        //         $query->where('hidden', '=', 0)
-        //             ->orWhere('startDate', '>=', $today->addDays());
-        //     });
-
-        // }
 
         $agendaItemQuery->orderBy('startDate', 'asc');
 

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -8,6 +8,7 @@ use App\Models\AgendaItemCategory;
 use App\Services\AgendaApplicationFormService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class AgendaController extends Controller
 {
@@ -42,6 +43,15 @@ class AgendaController extends Controller
             $endDate = Carbon::createFromFormat('d-m-Y', $endDate)->endOfDay();
             $agendaItemQuery->where('startDate', '<=', $endDate);
         }
+
+        // if (!Auth::user()->hasRole(Config::get('constants.Administrator'))) {
+        //     $today = Carbon::createFromFormat('d-m-Y', Carbon::now())->startOfDay();
+        //     $agendaItemQuery->where(function ($query) use ($today) {
+        //         $query->where('hidden', '=', 0)
+        //             ->orWhere('startDate', '>=', $today->addDays());
+        //     });
+
+        // }
 
         $agendaItemQuery->orderBy('startDate', 'asc');
 

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -46,8 +46,9 @@ class AgendaController extends Controller
         }
         
         # If user is not an administrator, filter out the hidden agenda items
-        if (Auth::user() == null || !Auth::user()->hasBackendRights()) {
-            $agendaItemQuery->where('hidden', '<>', 404)->where('hidden', 0)
+        if (Auth::guest() || !Auth::user()->hasRole(Config::get('constants.Administrator'))) {
+            $agendaItemQuery->where('hidden', 0)
+                ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden
                 ->orWhere(function ($query) {
                     $query->where('hidden', 1)->where('startDate', '<', Carbon::now()->addDays(8));
                 })
@@ -61,7 +62,6 @@ class AgendaController extends Controller
                     $query->where('hidden', 4)->where('startDate', '<', Carbon::now()->addDays(29));
                 });
         }
-
 
         $agendaItemQuery->orderBy('startDate', 'asc');
 

--- a/app/Http/Controllers/Api/AgendaController.php
+++ b/app/Http/Controllers/Api/AgendaController.php
@@ -50,16 +50,16 @@ class AgendaController extends Controller
             $agendaItemQuery->where('hidden', 0)
                 ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 1)->where('startDate', '<', Carbon::now()->addDays(8));
+                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 2)->where('startDate', '<', Carbon::now()->addDays(15));
+                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 3)->where('startDate', '<', Carbon::now()->addDays(22));
+                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
                 })
                 ->orWhere(function ($query) {
-                    $query->where('hidden', 4)->where('startDate', '<', Carbon::now()->addDays(29));
+                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
                 });
         }
 

--- a/app/Models/AgendaItem.php
+++ b/app/Models/AgendaItem.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Database\Factories\AgendaItemFactory;
 use App\Models\ApplicationForm\ApplicationForm;
 use App\Models\ApplicationForm\ApplicationResponse;
 use Carbon\Carbon;
@@ -10,10 +11,9 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+#[UseFactory(AgendaItemFactory::class)]
 class AgendaItem extends Model
 {
-    use HasFactory;
-
     protected $fillable = [
         'title',
         'text',

--- a/app/Models/AgendaItem.php
+++ b/app/Models/AgendaItem.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class AgendaItem extends Model
 {

--- a/app/Models/AgendaItem.php
+++ b/app/Models/AgendaItem.php
@@ -11,6 +11,8 @@ use Illuminate\Support\Facades\Storage;
 
 class AgendaItem extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'title',
         'text',

--- a/app/Models/AgendaItem.php
+++ b/app/Models/AgendaItem.php
@@ -21,6 +21,7 @@ class AgendaItem extends Model
         'image_url',
         'category',
         'climbing_activity',
+        'hidden',
     ];
 
     protected $casts = [

--- a/app/Models/AgendaItem.php
+++ b/app/Models/AgendaItem.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Database\Factories\AgendaItemFactory;
 use App\Models\ApplicationForm\ApplicationForm;
 use App\Models\ApplicationForm\ApplicationResponse;
 use Carbon\Carbon;
@@ -11,9 +10,10 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-#[UseFactory(AgendaItemFactory::class)]
 class AgendaItem extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'title',
         'text',

--- a/app/Repositories/AgendaItemRepository.php
+++ b/app/Repositories/AgendaItemRepository.php
@@ -29,7 +29,7 @@ class AgendaItemRepository implements IRepository
         $agendaItem->image_url = "";
         $agendaItem->createdBy = Auth::user()->id;
         $agendaItem->climbing_activity = array_key_exists('climbing_activity', $data);
-        $agendaItem->hidden = $data['hidden'];
+        $agendaItem->hidden = array_key_exists('hidden', $data) ? $data['hidden'] : 0;
         $agendaItem->save();
 
         return $agendaItem;
@@ -57,7 +57,7 @@ class AgendaItemRepository implements IRepository
         }
 
         $agendaItem->climbing_activity = array_key_exists('climbing_activity', $data);
-        $agendaItem->hidden = $data['hidden'];
+        $agendaItem->hidden = array_key_exists('hidden', $data) ? $data['hidden'] : 0;
         $agendaItem->save();
 
         return $agendaItem;

--- a/app/Repositories/AgendaItemRepository.php
+++ b/app/Repositories/AgendaItemRepository.php
@@ -29,6 +29,7 @@ class AgendaItemRepository implements IRepository
         $agendaItem->image_url = "";
         $agendaItem->createdBy = Auth::user()->id;
         $agendaItem->climbing_activity = array_key_exists('climbing_activity', $data);
+        $agendaItem->hidden = $data['hidden'];
         $agendaItem->save();
 
         return $agendaItem;
@@ -56,6 +57,7 @@ class AgendaItemRepository implements IRepository
         }
 
         $agendaItem->climbing_activity = array_key_exists('climbing_activity', $data);
+        $agendaItem->hidden = $data['hidden'];
         $agendaItem->save();
 
         return $agendaItem;

--- a/app/Repositories/AgendaItemRepository.php
+++ b/app/Repositories/AgendaItemRepository.php
@@ -107,9 +107,45 @@ class AgendaItemRepository implements IRepository
 
     public function getFirstXItems($limit)
     {
+        if (Auth::guest()) {
+            return AgendaItem::query()
+                ->with('getApplicationFormResponses')
+                ->whereDate('startDate', '>=', Carbon::now())
+                ->where('hidden', 0)
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
+                })
+                ->orWhere(function ($query) {
+                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
+                })
+                ->orderBy('startDate', 'ASC')
+                ->take($limit)
+                ->get();
+        }
+        
         return AgendaItem::query()
             ->with('getApplicationFormResponses')
             ->whereDate('startDate', '>=', Carbon::now())
+            ->where('hidden', 0)
+            ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden
+            ->orWhere(function ($query) {
+                $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
+            })
+            ->orWhere(function ($query) {
+                $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
+            })
+            ->orWhere(function ($query) {
+                $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
+            })
+            ->orWhere(function ($query) {
+                $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
+            })
             ->orderBy('startDate', 'ASC')
             ->take($limit)
             ->get();

--- a/app/Repositories/AgendaItemRepository.php
+++ b/app/Repositories/AgendaItemRepository.php
@@ -106,34 +106,11 @@ class AgendaItemRepository implements IRepository
     }
 
     public function getFirstXItems($limit)
-    {
-        if (Auth::guest()) {
-            return AgendaItem::query()
-                ->with('getApplicationFormResponses')
-                ->whereDate('startDate', '>=', Carbon::now())
-                ->where('hidden', 0)
-                ->orWhere(function ($query) {
-                    $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
-                })
-                ->orWhere(function ($query) {
-                    $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
-                })
-                ->orWhere(function ($query) {
-                    $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
-                })
-                ->orWhere(function ($query) {
-                    $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
-                })
-                ->orderBy('startDate', 'ASC')
-                ->take($limit)
-                ->get();
-        }
-        
+    {   
         return AgendaItem::query()
             ->with('getApplicationFormResponses')
             ->whereDate('startDate', '>=', Carbon::now())
             ->where('hidden', 0)
-            ->orWhere('createdBy', Auth::user()->id) # items made by user are not hidden
             ->orWhere(function ($query) {
                 $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
             })

--- a/app/Repositories/AgendaItemRepository.php
+++ b/app/Repositories/AgendaItemRepository.php
@@ -109,19 +109,19 @@ class AgendaItemRepository implements IRepository
     {   
         return AgendaItem::query()
             ->with('getApplicationFormResponses')
-            ->whereDate('startDate', '>=', Carbon::now())
+            ->whereDate('startDate', '>=', Carbon::now('Europe/Amsterdam'))
             ->where('hidden', 0)
             ->orWhere(function ($query) {
-                $query->where('hidden', 1)->where('startDate', '<=', Carbon::now()->addDays(7));
+                $query->where('hidden', 1)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(7));
             })
             ->orWhere(function ($query) {
-                $query->where('hidden', 2)->where('startDate', '<=', Carbon::now()->addDays(14));
+                $query->where('hidden', 2)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(14));
             })
             ->orWhere(function ($query) {
-                $query->where('hidden', 3)->where('startDate', '<=', Carbon::now()->addDays(21));
+                $query->where('hidden', 3)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(21));
             })
             ->orWhere(function ($query) {
-                $query->where('hidden', 4)->where('startDate', '<=', Carbon::now()->addDays(28));
+                $query->where('hidden', 4)->where('startDate', '<=', Carbon::now('Europe/Amsterdam')->addDays(28));
             })
             ->orderBy('startDate', 'ASC')
             ->take($limit)

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -22,6 +22,6 @@ $factory->define(AgendaItem::class, function (Faker $faker) {
         'subscription_endDate' => $faker->date,
         'image_url' => $faker->imageUrl,
         'climbing_activity' => $faker->boolean,
-        'hidden' => $faker->randomElement([0,1,2,3,4]),
+        'hidden' => $faker->randomElement([0,1,2,3,4,404]),
     ];
 });

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -6,7 +6,6 @@ use App\Models\AgendaItem;
 use App\Models\AgendaItemCategory;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\User;
-use Faker\Generator as Faker;
 
 class AgendaItemFactory extends Factory
 {

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\AgendaItem;
 use App\Models\AgendaItemCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\User;
 use Faker\Generator as Faker;
 

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -7,21 +7,82 @@ use App\Models\AgendaItemCategory;
 use App\Models\User;
 use Faker\Generator as Faker;
 
-$factory->define(AgendaItem::class, function (Faker $faker) {
-    $user = User::factory()->create();
-    $category = factory(AgendaItemCategory::class)->create();
+class AgendaItemFactory extends Factory
+{
+    public function definition(): array
+    {
+        $user = User::factory()->create();
+        $category = factory(AgendaItemCategory::class)->create();
 
-    return [
-        'title' => $faker->word,
-        'text'=> $faker->text,
-        'shortDescription' => $faker->word,
-        'createdBy' => $user->id,
-        'category' => $category->id,
-        'startDate' => $faker->date,
-        'endDate' => $faker->date,
-        'subscription_endDate' => $faker->date,
-        'image_url' => $faker->imageUrl,
-        'climbing_activity' => $faker->boolean,
-        'hidden' => $faker->randomElement([0,1,2,3,4,5]),
-    ];
-});
+        return [
+            'title' => fake()->word(),
+            'text'=> fake()->text(),
+            'shortDescription' => fake()->word(),
+            'createdBy' => $user->id,
+            'category' => $category->id,
+            'startDate' => fake()->date(),
+            'endDate' => fake()->date(),
+            'subscription_endDate' => fake()->date(),
+            'image_url' => fake()->imageUrl(),
+            'climbing_activity' => fake()->boolean(),
+            'hidden' => fake()->randomElement([0,1,2,3,4,5]),
+        ];
+    }
+
+    // hidden variations
+    
+    public function not_hidden(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'hidden' => 0,
+            ];
+        });
+    }
+
+    public function hidden_1week(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'hidden' => 1,
+            ];
+        });
+    }
+
+    public function hidden_2weeks(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'hidden' => 2,
+            ];
+        });
+    }
+
+    public function hidden_3weeks(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'hidden' => 3,
+            ];
+        });
+    }
+
+    public function hidden_4weeks(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'hidden' => 4,
+            ];
+        });
+    }
+
+    public function hidden(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'hidden' => 5,
+            ];
+        });
+    }
+
+}

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -4,8 +4,8 @@ namespace Database\Factories;
 
 use App\Models\AgendaItem;
 use App\Models\AgendaItemCategory;
-use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 class AgendaItemFactory extends Factory
 {

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -22,5 +22,6 @@ $factory->define(AgendaItem::class, function (Faker $faker) {
         'subscription_endDate' => $faker->date,
         'image_url' => $faker->imageUrl,
         'climbing_activity' => $faker->boolean,
+        'hidden' => $faker->randomElement([0,1,2,3,4]),
     ];
 });

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -22,6 +22,6 @@ $factory->define(AgendaItem::class, function (Faker $faker) {
         'subscription_endDate' => $faker->date,
         'image_url' => $faker->imageUrl,
         'climbing_activity' => $faker->boolean,
-        'hidden' => $faker->randomElement([0,1,2,3,4,404]),
+        'hidden' => $faker->randomElement([0,1,2,3,4,5]),
     ];
 });

--- a/database/factories/ApplicationResponseFactory.php
+++ b/database/factories/ApplicationResponseFactory.php
@@ -10,7 +10,7 @@ use Faker\Generator as Faker;
 
 $factory->define(ApplicationResponse::class, function (Faker $faker) {
     $user = User::factory()->create();
-    $agendaItem = factory(AgendaItem::class)->create();
+    $agendaItem = AgendaItem::factory()->not_hidden()->create();
     $applicationForm = factory(ApplicationForm::class)->create();
     return [
         'user_id' => $user->id,

--- a/database/migrations/2026_09_11_091042_add_hidden_to_agenda_items_table.php
+++ b/database/migrations/2026_09_11_091042_add_hidden_to_agenda_items_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('agenda_items', function (Blueprint $table) {
+            $table->integer('hidden')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('agenda_items', function (Blueprint $table) {
+            $table->dropColumn('hidden');
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -31,7 +31,6 @@ CREATE TABLE `agenda_items` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   `climbing_activity` tinyint(1) NOT NULL DEFAULT '1',
-  `hidden` int unsigned NOT NULL DEFAULT 0,
   `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `text` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `shortDescription` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE `agenda_items` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   `climbing_activity` tinyint(1) NOT NULL DEFAULT '1',
-  `hidden` tinyint(1) NOT NULL DEFAULT '0',
+  `hidden` int unsigned NOT NULL DEFAULT 0,
   `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `text` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `shortDescription` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE `agenda_items` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   `climbing_activity` tinyint(1) NOT NULL DEFAULT '1',
+  `hidden` tinyint(1) NOT NULL DEFAULT '0',
   `title` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `text` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `shortDescription` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,

--- a/database/seeders/AgendaItemSeeder.php
+++ b/database/seeders/AgendaItemSeeder.php
@@ -36,7 +36,7 @@ class AgendaItemSeeder extends Seeder
         $agendaItem->text = 'Climbing at Neoliet North text';
         $agendaItem->shortDescription = 'Climbing at Neoliet North';
         $agendaItem->image_url = "";
-        $agendaItem->createdBy = 1;
+        $agendaItem->createdBy = 2;
         $agendaItem->category = 1;
         $agendaItem->application_form_id = 2;
         $agendaItem->hidden = 5;

--- a/database/seeders/AgendaItemSeeder.php
+++ b/database/seeders/AgendaItemSeeder.php
@@ -39,6 +39,7 @@ class AgendaItemSeeder extends Seeder
         $agendaItem->createdBy = 1;
         $agendaItem->category = 1;
         $agendaItem->application_form_id = 2;
+        $agendaItem->hidden = 5;
         $agendaItem->save();
 
         $agendaItem = new AgendaItem();

--- a/resources/lang/en/hide_agenda.php
+++ b/resources/lang/en/hide_agenda.php
@@ -6,5 +6,5 @@ return [
     2 => "Until 2 weeks before",
     3 => "Until 3 weeks before",
     4 => "Until 4 weeks before",
-    5 => "Indefinitely"
+    5 => "Hidden"
 ];

--- a/resources/lang/en/hide_agenda.php
+++ b/resources/lang/en/hide_agenda.php
@@ -6,5 +6,5 @@ return [
     2 => "Until 2 weeks before",
     3 => "Until 3 weeks before",
     4 => "Until 4 weeks before",
-    404 => "Indefinitely"
+    5 => "Indefinitely"
 ];

--- a/resources/lang/en/hide_agenda.php
+++ b/resources/lang/en/hide_agenda.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    0 => "Show immediately",
+    1 => "Until 1 week before",
+    2 => "Until 2 weeks before",
+    3 => "Until 3 weeks before",
+    4 => "Until 4 weeks before",
+];

--- a/resources/lang/en/hide_agenda.php
+++ b/resources/lang/en/hide_agenda.php
@@ -6,4 +6,5 @@ return [
     2 => "Until 2 weeks before",
     3 => "Until 3 weeks before",
     4 => "Until 4 weeks before",
+    404 => "Indefinitely"
 ];

--- a/resources/views/beheer/agendaItem/create_edit_default_info.blade.php
+++ b/resources/views/beheer/agendaItem/create_edit_default_info.blade.php
@@ -49,5 +49,11 @@
                 {!! Form::checkbox('climbing_activity', 1, ($agendaItem != null) ? $agendaItem->climbing_activity : true, ['class' => 'form-control']) !!}
             </div>
         </div>
+        <div class="form-row">
+            <div class="form-group col-md-6">
+                {!! Form::label('hidden', 'Hide agenda item') !!}
+                {!! Form::select('hidden',trans("hide_agenda"), ($agendaItem != null) ? $agendaItem->hidden : "", ['class' => 'form-control','required' => 'required']) !!}
+            </div>
+        </div>
     </div>
 </div>

--- a/resources/views/beheer/agendaItem/index.blade.php
+++ b/resources/views/beheer/agendaItem/index.blade.php
@@ -46,11 +46,11 @@
     <table id="agenda-items" class="table table-striped dt-responsive nowrap" style="width:100%">
         <thead>
         <tr>
+            <th>{{''}}</th>
             <th>{{'Title'}}</th>
             <th>{{'Start date'}}</th>
             <th>{{'End date'}}</th>
             <th>{{'Management'}}</th>
-            <th>{{'Hidden'}}</th>
         </tr>
         </thead>
         <tbody>
@@ -95,10 +95,19 @@
                 "dataSrc": "agendaItems"
             },
             columnDefs: [
-                {type: 'de_datetime', targets: 1},
                 {type: 'de_datetime', targets: 2},
+                {type: 'de_datetime', targets: 3},
+                {width: '15%', targets: 4},
+                {width: '3%', targets: 0},
+                {orderable: false, targets: 0},
+                {orderable: false, targets: 4},
             ],
             "columns": [
+                {
+                    "data": function (data) {
+                        return getHidden(data);
+                    }
+                },
                 {"data": "title"},
                 {
                     "data": function (data) {
@@ -113,11 +122,6 @@
                 {
                     "data": function (data) {
                         return getAgendaItemActions(data);
-                    }
-                },
-                {
-                    "data": function (data) {
-                        return getHidden(data);
                     }
                 },
             ]
@@ -143,11 +147,25 @@
             return actions;
         }
 
+        // Helper for getHidden
+        function addDays(date, days) {
+            var result = new Date(date);
+            result.setDate(result.getDate() + days);
+            return result;
+        }
+
         function getHidden(data) {
             let hidden = false;
+            var now = new Date()
+            var startDate = moment(data.full_startDate)
+
             if (data.hidden == 5) hidden = true;
-            if (data.id == 7) console.log(data)
-            if (hidden) return '<a class="mr-1 ml-1" href="{{url('agendaItems')}}/' + data.id + '"><span title="{{'Show event'}}" class="ion-eye font-size-120 icon" aria-hidden="true"></span></a>';
+            else if (data.hidden == 1 && startDate > addDays(now, 7)) hidden = true;
+            else if (data.hidden == 2 && startDate > addDays(now, 14)) hidden = true;
+            else if (data.hidden == 3 && startDate > addDays(now, 21)) hidden = true;
+            else if (data.hidden == 4 && startDate > addDays(now, 28)) hidden = true;
+
+            if (hidden) return '<a><span title="{{'Event hidden'}}" class="ion-eye-disabled font-size-120 icon" aria-hidden="true"></span></a>';
             else return "";
         }
 

--- a/resources/views/beheer/agendaItem/index.blade.php
+++ b/resources/views/beheer/agendaItem/index.blade.php
@@ -175,6 +175,7 @@
             if (datePicker.val() != "") {
                 params += "&startDate=" + datePicker.val();
             }
+            params += "&beheer=true"
 
             return "{{url("api/agenda")}}?" + params;
         }

--- a/resources/views/beheer/agendaItem/index.blade.php
+++ b/resources/views/beheer/agendaItem/index.blade.php
@@ -50,6 +50,7 @@
             <th>{{'Start date'}}</th>
             <th>{{'End date'}}</th>
             <th>{{'Management'}}</th>
+            <th>{{'Hidden'}}</th>
         </tr>
         </thead>
         <tbody>
@@ -114,6 +115,11 @@
                         return getAgendaItemActions(data);
                     }
                 },
+                {
+                    "data": function (data) {
+                        return getHidden(data);
+                    }
+                },
             ]
         });
 
@@ -135,6 +141,14 @@
             }
             actions += '<a class="mr-1 ml-1" href="{{url('agendaItems')}}/' + data.id + '/copy"><span title="{{'Copy event'}}" class="ion-ios-copy font-size-120 icon" aria-hidden="true"></span></a>';
             return actions;
+        }
+
+        function getHidden(data) {
+            let hidden = false;
+            if (data.hidden == 5) hidden = true;
+            if (data.id == 7) console.log(data)
+            if (hidden) return '<a class="mr-1 ml-1" href="{{url('agendaItems')}}/' + data.id + '"><span title="{{'Show event'}}" class="ion-eye font-size-120 icon" aria-hidden="true"></span></a>';
+            else return "";
         }
 
         function getUrl() {

--- a/resources/views/beheer/agendaItem/show.blade.php
+++ b/resources/views/beheer/agendaItem/show.blade.php
@@ -66,6 +66,10 @@
                     <td>{{$agendaItem->climbing_activity ? 'Yes' : 'No'}}</td>
                 </tr>
                 <tr>
+                    <td>{{'Hide agenda item'}}</td>
+                    <td>{{trans("hide_agenda.".$agendaItem->hidden)}}</td>
+                </tr>
+                <tr>
                     <td>{{'Created by'}}</td>
                     <td>{{$agendaItem->getCreatedBy->getName()}}</td>
                 </tr>

--- a/resources/views/front-end/home.blade.php
+++ b/resources/views/front-end/home.blade.php
@@ -57,47 +57,47 @@
             <div class="col-auto">
                 <h3>{{'Activities'}}</h3>
             </div>
-            <div class="col-auto">
+            <div class="col-auto">  
                 <a href="{{url('agenda')}}" class="btn btn-outline-primary">{{'See more'}}</a>
             </div>
         </div>
         <div class="row d-flex align-items-stretch align-items-center">
             @foreach($agendaItems as $agendaItem)
-            <div class="col-sm-12 d-flex flex-wrap">
-                <div class="card w-100 position-relative">
-                    <a href="/agenda/{{$agendaItem->id}} ">
-                        <img class="card-img-top " src="{{$agendaItem->getImageUrl()}}" alt="Card image cap">
-                    </a>
-                    <span class="card-date position-absolute bg-light py-1 px-3 rounded">{{\Carbon\Carbon::parse($agendaItem->startDate)->format('d M')}}</span>
-                    <div class="card-body">
-                    <a href="/agenda/{{$agendaItem->id}} ">
+                <div class="col-sm-12 d-flex flex-wrap">
+                    <div class="card w-100 position-relative">
+                        <a href="/agenda/{{$agendaItem->id}} ">
+                            <img class="card-img-top " src="{{$agendaItem->getImageUrl()}}" alt="Card image cap">
+                        </a>
+                        <span class="card-date position-absolute bg-light py-1 px-3 rounded">{{\Carbon\Carbon::parse($agendaItem->startDate)->format('d M')}}</span>
+                        <div class="card-body">
+                        <a href="/agenda/{{$agendaItem->id}} ">
 
-                            <h4 class="card-title">{{$agendaItem->title}}</h4>
-                            <p class="card-text text-body">{{$agendaItem->shortDescription}}</p>
-                    </a>
-                    </div>
-                    @if($agendaItem->application_form_id != null)
-                    <div class="card-footer bg-white p-3">
-                        <div class="row justify-content-between align-items-center">
-                            <div class="col-auto text-muted">
-                                <span class="ion-person-stalker"></span> {{count($agendaItem->getApplicationFormResponses)}}
-                            </div>
-                            <div class="col-auto">
-                                @if(Auth::guest())
-                                    {{'Please log in to register'}}
-                                @else
-                                    @if($agendaItem->canRegister())
-                                        <a class="btn btn-outline-primary" href="{{url('')}}/forms/{{$agendaItem->id}}">{{'Register now'}}</a>
+                                <h4 class="card-title">{{$agendaItem->title}}</h4>
+                                <p class="card-text text-body">{{$agendaItem->shortDescription}}</p>
+                        </a>
+                        </div>
+                        @if($agendaItem->application_form_id != null)
+                        <div class="card-footer bg-white p-3">
+                            <div class="row justify-content-between align-items-center">
+                                <div class="col-auto text-muted">
+                                    <span class="ion-person-stalker"></span> {{count($agendaItem->getApplicationFormResponses)}}
+                                </div>
+                                <div class="col-auto">
+                                    @if(Auth::guest())
+                                        {{'Please log in to register'}}
                                     @else
-                                        {{'Registration not possible'}}
+                                        @if($agendaItem->canRegister())
+                                            <a class="btn btn-outline-primary" href="{{url('')}}/forms/{{$agendaItem->id}}">{{'Register now'}}</a>
+                                        @else
+                                            {{'Registration not possible'}}
+                                        @endif
                                     @endif
-                                @endif
+                                </div>
                             </div>
                         </div>
+                        @endif
                     </div>
-                    @endif
                 </div>
-            </div>
             @endforeach
         </div>
     </div>

--- a/tests/Feature/Agenda/AgendaFilterTest.php
+++ b/tests/Feature/Agenda/AgendaFilterTest.php
@@ -45,12 +45,12 @@ class AgendaFilterTest extends TestCase
     public function api_returns_filtered_agenda_items()
     {
         $agendaItemCategory = factory(AgendaItemCategory::class)->create();
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
         $agendaItem->category = $agendaItemCategory->id;
         $agendaItem->save();
 
-        factory(AgendaItem::class)->create();
-        factory(AgendaItem::class)->create();
+        AgendaItem::factory()->not_hidden()->create();
+        AgendaItem::factory()->not_hidden()->create();
 
         $response = $this->get($this->url . "?category=" . $agendaItemCategory->id);
         $json = json_decode($response->getContent());

--- a/tests/Feature/Agenda/CopyAgendaItem.php
+++ b/tests/Feature/Agenda/CopyAgendaItem.php
@@ -58,6 +58,7 @@ class CopyAgendaItem extends TestCase
         $this->assertEquals($agendaItem->endDate, $newAgendaItem->endDate);
         $this->assertEquals($agendaItem->category, $newAgendaItem->category);
         $this->assertEquals($agendaItem->climbing_activity, $newAgendaItem->climbing_activity);
+        $this->assertEquals($agendaItem->hidden, $newAgendaItem->hidden);
 
         $this->assertEquals($agendaItem->title, $newAgendaItem->title);
         $this->assertEquals($agendaItem->text, $newAgendaItem->text);

--- a/tests/Feature/Agenda/CopyAgendaItem.php
+++ b/tests/Feature/Agenda/CopyAgendaItem.php
@@ -43,7 +43,7 @@ class CopyAgendaItem extends TestCase
 
     /** @test */
     public function agenda_item_can_be_copied(){
-        $agendaItem = factory(AgendaItem::class)->create(['image_url' => ""]);
+        $agendaItem = AgendaItem::factory()->not_hidden()->create(['image_url' => ""]);
 
         $response = $this->get($this->url . $agendaItem->id . '/copy');
 

--- a/tests/Feature/Agenda/DeleteAgendaItemTest.php
+++ b/tests/Feature/Agenda/DeleteAgendaItemTest.php
@@ -39,7 +39,7 @@ class DeleteAgendaItemTest extends TestCase
     /** @test */
     public function DeleteAgendaItem()
     {
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
 
         $response = $this->delete($this->url . '/' . $agendaItem->id);
 

--- a/tests/Feature/Agenda/RegisterForAgendaItemTest.php
+++ b/tests/Feature/Agenda/RegisterForAgendaItemTest.php
@@ -48,7 +48,7 @@ class RegisterForAgendaItemTest extends TestCase
     /** @test */
     public function show_event_registration_form_for_agenda_item_without_registration_form()
     {
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
         $agendaItem->subscription_endDate = Carbon::now()->addWeek();
         $agendaItem->save();
         $response = $this->get($this->url . $agendaItem->id);
@@ -60,7 +60,7 @@ class RegisterForAgendaItemTest extends TestCase
     /** @test */
     public function show_event_registration_form_for_agenda_item_with_past_subscription_date()
     {
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
         $agendaItem->subscription_endDate = Carbon::now()->subWeek();
         $agendaItem->save();
         $response = $this->get($this->url . $agendaItem->id);
@@ -72,7 +72,7 @@ class RegisterForAgendaItemTest extends TestCase
     /** @test */
     public function show_event_registration_form_for_agenda_item_where_user_is_already_registered()
     {
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
         $applicationForm = factory(ApplicationForm::class)->create();
 
         $agendaItem->application_form_id = $applicationForm->id;
@@ -94,7 +94,7 @@ class RegisterForAgendaItemTest extends TestCase
     /** @test */
     public function register_for_agenda_item(): void
     {
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
         $applicationForm = factory(ApplicationForm::class)->create();
 
         $agendaItem->application_form_id = $applicationForm->id;
@@ -143,7 +143,7 @@ class RegisterForAgendaItemTest extends TestCase
     public function register_user_for_agenda_item_as_normale_member_should_not_be_allowed(): void
     {
         $userToRegister = User::factory()->create();
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
         $applicationForm = factory(ApplicationForm::class)->create();
 
         $agendaItem->application_form_id = $applicationForm->id;
@@ -180,7 +180,7 @@ class RegisterForAgendaItemTest extends TestCase
     {
         $this->user->roles()->attach(Config::get('constants.Content_administrator'));
         $userToRegister = User::factory()->create();
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->not_hidden()->create();
         $applicationForm = factory(ApplicationForm::class)->create();
 
         $agendaItem->application_form_id = $applicationForm->id;

--- a/tests/Feature/Agenda/UpdateAgendaItemTest.php
+++ b/tests/Feature/Agenda/UpdateAgendaItemTest.php
@@ -42,7 +42,7 @@ class UpdateAgendaItemTest extends TestCase
     /** @test */
     public function UpdateAgendaItemTest()
     {
-        $agendaItem = factory(AgendaItem::class)->create();
+        $agendaItem = AgendaItem::factory()->create();
         $agendaItemCategory = factory(AgendaItemCategory::class)->create();
 
         $body = [


### PR DESCRIPTION
Adds the option to hide agenda items to the creation page. People can specify until when they want their agenda item to be hidden and can choose between: "Show immediately", "Until 1,2,3,4 weeks before" and "Indefinitely".

Has the potential to break the agenda page, so would be nice if a second person also tested this locally with some edge cases.